### PR TITLE
removing unneeded fact evaluation

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -146,7 +146,7 @@ class gitlab::config {
       tries       => 5,
     }
 
-    if is_hash($postgresql) {
+    if $postgresql =~ Hash {
       unless $postgresql[enable] {
         exec { 'gitlab_setup':
           command     => "/bin/echo yes | ${rake_exec} gitlab:setup",

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -49,15 +49,16 @@ class gitlab::install {
         }
       }
       'redhat': {
-
         $gpgkey = $edition ? {
             'ee'    => 'https://packages.gitlab.com/gitlab/gitlab-ce/gpgkey https://packages.gitlab.com/gitlab/gitlab-ee/gpgkey/gitlab-gitlab-ee-3D645A26AB9FBD22.pub.gpg',
             'ce'    => 'https://packages.gitlab.com/gitlab/gitlab-ce/gpgkey https://packages.gitlab.com/gitlab/gitlab-ce/gpgkey/gitlab-gitlab-ce-3D645A26AB9FBD22.pub.gpg'
         }
 
+        $releasever = $facts['os']['release']['major']
+
         yumrepo { "gitlab_official_${edition}":
           descr         => 'Official repository for Gitlab',
-          baseurl       => "https://packages.gitlab.com/gitlab/gitlab-${edition}/el/${::operatingsystemmajrelease}/\$basearch",
+          baseurl       => "https://packages.gitlab.com/gitlab/gitlab-${edition}/el/${releasever}/\$basearch",
           enabled       => 1,
           repo_gpgcheck => 1,
           gpgcheck      => 1,


### PR DESCRIPTION
the $::os fact hash has been around since 3.5 (and puppet 3 is EOL) this change removes the is_hash dependency provided by stdlib (which is deprecated). 

Supporting references:
https://github.com/puppetlabs/puppetlabs-stdlib#is_hash

Replacements for the is_ functions:
In param block: https://github.com/puppetlabs/puppetlabs-ntp/blob/master/manifests/init.pp#L17-L28
In code block: https://docs.puppet.com/puppet/4.8/lang_expressions.html#regex-or-data-type-match

Note: both of the replacements for is_* are only compatible with puppet 4.0.0 and later, I have updated the metadata.json to reflect this, and I would recommend releasing a new major release version to the forge.