### PR TITLE
fix typo

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -487,7 +487,7 @@ class gitlab (
   validate_integer($backup_cron_hour,23)
   validate_array($backup_cron_skips)
   validate_hash($custom_hooks)
-  validate_hash($glocal_hooks)
+  validate_hash($global_hooks)
 
   class { '::gitlab::install': } ->
   class { '::gitlab::config': } ~>


### PR DESCRIPTION
The variable "glocal_hooks" does not exists, so it resulted in this error: 

`Error: "" is not a Hash.  It looks to be a String at /tmp/vagrant-puppet/modules-7ee4745f90860a506980a9923d6fea86/gitlab/manifests/init.pp:490 on node puppet.localdomain`