### PR TITLE
Db indexing for git authorized keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ the `$::os` fact used in `install.pp` doesn't work as expected.
 
 ### Beginning with Gitlab
 
-Just include the class and specify at least `external_url`. If `external_url` is not specified it will default to the FQDN fact of the system. 
+Just include the class and specify at least `external_url`. If `external_url` is not specified it will default to the FQDN fact of the system.
 
 ```puppet
 class { 'gitlab':
@@ -248,7 +248,7 @@ gitlab::custom_hooks:
 
 Since GitLab Shell 4.1.0 and GitLab 8.15 Chained hooks are supported. You can
 create global hooks which will run for each repository on your server. Global
-hooks can be created as a pre-receive, post-receive, or update hook. 
+hooks can be created as a pre-receive, post-receive, or update hook.
 
 ```puppet
 gitlab::global_hook { 'my_custom_hook':
@@ -265,6 +265,19 @@ gitlab::global_hooks:
     type: post-receive
     source: 'puppet:///modules/my_module/post-receive'
 ```
+
+### Fast Lookup of SSH keys
+
+GitLab instances with a large number of users may notice slowdowns when making initial connections for ssh operations.
+GitLab has created a feature that allows authorized ssh keys to be stored in the db (instead of the `authorized_keys`
+file for the `git` user)
+
+You can enable this feature in GitLab using the `store_git_keys_in_db` parameter.
+
+Please note, managing the sshd service and openssh is outside the scope of this module.
+You will need to configure the AuthorizedKeysCommand for the `git` user in sshd.server yourself.
+Instructions for this are provided by GitLab at
+[Fast lookup of authorized SSH keys in the databasse](https://docs.gitlab.com/ee/administration/operations/fast_ssh_key_lookup.html)
 
 ### Gitlab CI Runner Limitations
 

--- a/files/gitlab_shell_authorized_keys
+++ b/files/gitlab_shell_authorized_keys
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if [[ "$1" == "git" ]]; then
+  /opt/gitlab/embedded/service/gitlab-shell/bin/authorized_keys $2
+fi

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -181,6 +181,32 @@ class gitlab::config {
     }
   }
 
+  if $store_git_keys_in_db != undef {
+    $_store_git_keys_in_db = $store_git_keys_in_db ? {
+      true    => 'file',
+      default => 'absent',
+    }
+
+    $opt_gitlab_shell_dir = $store_git_keys_in_db ? {
+      true    => 'directory',
+      default => 'absent'
+    }
+
+    file {'/opt/gitlab-shell':
+      ensure => $opt_gitlab_shell_dir,
+      owner  => 'root',
+      group  => 'git',
+    }
+
+    file {'/opt/gitlab-shell/authorized_keys':
+      ensure  => $_store_git_keys_in_db,
+      owner   => 'root',
+      group   => 'git',
+      mode    => '0650',
+      source  => 'puppet:///modules/gitlab/gitlab_shell_authorized_keys'
+    }
+  }
+
   if $backup_cron_enable {
     cron {'gitlab backup':
       command => "${rake_exec} gitlab:backup:create CRON=1 ${backup_cron_skips}",

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -67,6 +67,7 @@ class gitlab::config {
   $sidekiq = $::gitlab::sidekiq
   $sidekiq_cluster = $::gitlab::sidekiq_cluster
   $skip_auto_migrations = $::gitlab::skip_auto_migrations
+  $store_git_keys_in_db = $::gitlab::store_git_keys_in_db
   $source_config_file = $::gitlab::source_config_file
   $unicorn = $::gitlab::unicorn
   $gitlab_workhorse = $::gitlab::gitlab_workhorse

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,7 +60,7 @@
 #
 # [*rake_exec*]
 #   Default: '/usr/bin/gitlab-rake'
-#   The gitlab-rake executable path. 
+#   The gitlab-rake executable path.
 #   You should not need to change this path.
 #
 # [*edition*]
@@ -276,6 +276,12 @@
 #   Default: undef
 #   Enable or disable auto migrations. undef keeps the current state on the system.
 #
+# [*store_git_keys_in_db*]
+#   Default: false
+#   Enable or disable Fast Lookup of authorized SSH keys in the database
+#   See: https://docs.gitlab.com/ee/administration/operations/fast_ssh_key_lookup.html
+#
+#
 # [*source_config_file*]
 #   Default: undef
 #   Override Hiera config with path to gitlab.rb config file.
@@ -408,6 +414,7 @@ class gitlab (
   $sidekiq_cluster = undef,
   $skip_auto_migrations = undef,
   $source_config_file = undef,
+  $store_git_keys_in_db = false,
   $unicorn = undef,
   $gitlab_workhorse = undef,
   $user = undef,
@@ -433,6 +440,7 @@ class gitlab (
   # gitlab specific
   validate_re($edition, [ '^ee$', '^ce$' ])
   validate_bool($config_manage)
+  validate_bool($store_git_keys_in_db)
   validate_absolute_path($config_file)
   if $custom_hooks_dir { validate_absolute_path($custom_hooks_dir) }
   if $geo_postgresql { validate_hash($geo_postgresql) }
@@ -496,7 +504,7 @@ class gitlab (
   contain gitlab::install
   contain gitlab::config
   contain gitlab::service
- 
+
   create_resources(gitlab::custom_hook, $custom_hooks)
   create_resources(gitlab::global_hook, $global_hooks)
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -194,7 +194,7 @@ describe 'gitlab', :type => :class do
 
           it do
             is_expected.to contain_file('/opt/gitlab-shell/authorized_keys')
-              .with_content(/\/opt\/gitlab\/embedded\/service\/gitlab-shell\/bin\/authorized_key/)
+              .with_content(/^\s*\/opt\/gitlab\/embedded\/service\/gitlab-shell\/bin\/authorized_key/)
           end
         end
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -194,7 +194,6 @@ describe 'gitlab', :type => :class do
 
           it do
             is_expected.to contain_file('/opt/gitlab-shell/authorized_keys')
-              .with_content(/^\s*\/opt\/gitlab\/embedded\/service\/gitlab-shell\/bin\/authorized_keys/)
           end
         end
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -189,6 +189,14 @@ describe 'gitlab', :type => :class do
             .with_content(%r{"/var/opt/data"})
           end
         end
+        describe 'with store_git_keys_in_db' do
+          let(:params) {{ 'store_git_keys_in_db' => true }}
+
+          it do
+            is_expected.to contain_file('/opt/gitlab-shell/authorized_keys')
+              .with_content(%r{/opt/gitlab/embedded/service/gitlab-shell/bin/authorized_key})
+          end
+        end
       end
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -194,7 +194,7 @@ describe 'gitlab', :type => :class do
 
           it do
             is_expected.to contain_file('/opt/gitlab-shell/authorized_keys')
-              .with_content(%r{/opt/gitlab/embedded/service/gitlab-shell/bin/authorized_key})
+              .with_content(/\/opt\/gitlab\/embedded\/service\/gitlab-shell\/bin\/authorized_key/)
           end
         end
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -194,7 +194,7 @@ describe 'gitlab', :type => :class do
 
           it do
             is_expected.to contain_file('/opt/gitlab-shell/authorized_keys')
-              .with_content(/^\s*\/opt\/gitlab\/embedded\/service\/gitlab-shell\/bin\/authorized_key/)
+              .with_content(/^\s*\/opt\/gitlab\/embedded\/service\/gitlab-shell\/bin\/authorized_keys/)
           end
         end
       end


### PR DESCRIPTION
This enhancement allows for fast lookups for ssh keys for communicating with gitlab instances using git+ssh protocol.

As described in the speed up ssh operations documentation, gitlab has a feature that will allow the gitlab_shell to index authorized_keys for git+ssh connections in the database instead of the authorized_keys file. This can drastically impact the speed of ssh connections when a large number of keys or users are present.

closes #168 