### PR TITLE
Add requirement for puppet 4.6+

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Unreleased
+* Drop support for puppet less than 4.7
+
 ## v1.16.0 [2017-12-13]
 
 * **Migration to Vox Pupuli**
@@ -49,7 +52,7 @@
 
 ## v1.12.0 [2017-04-03]
 
-* Fixed gitlab.rb template for Integers in `gitlab_rails` setting because of rack_attack_git_basic_auth will fail during gitlab reconfiguration if the Integer Values are Strings. 
+* Fixed gitlab.rb template for Integers in `gitlab_rails` setting because of rack_attack_git_basic_auth will fail during gitlab reconfiguration if the Integer Values are Strings.
 * Add dependencies to apt-transport-https, xz-utils
 * Merge hashes for runner configuration
 * Fix use of integers in gitlab_rails settings

--- a/metadata.json
+++ b/metadata.json
@@ -68,7 +68,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=3.7.0 <5.0.0"
+      "version_requirement": ">= 4.7.0 <6.0.0"
     }
   ]
 }


### PR DESCRIPTION
  * this alone doesn't change any code but lets folks now we will
    be dropping support for puppet less than 4.7.  Why pupppet 4.7?
    Puppet 4.7 officially added support for datatypes which I think
    is the minimal version required.  Since stdlib provides many
    excellent datatypes we will need 4.7 support to load those external
    types.  

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
