### PR TITLE
add letsencrypt section to gitlab.rb

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,6 +29,7 @@ class gitlab::config {
   $gitlab_pages = $::gitlab::gitlab_pages
   $gitlab_rails = $::gitlab::gitlab_rails
   $high_availability = $::gitlab::high_availability
+  $letsencrypt = $::gitlab::letsencrypt
   $logging = $::gitlab::logging
   $logrotate = $::gitlab::logrotate
   $manage_storage_directories = $::gitlab::manage_storage_directories

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,7 +60,7 @@
 #
 # [*rake_exec*]
 #   Default: '/usr/bin/gitlab-rake'
-#   The gitlab-rake executable path. 
+#   The gitlab-rake executable path.
 #   You should not need to change this path.
 #
 # [*edition*]
@@ -142,6 +142,10 @@
 # [*logging*]
 #   Default: undef
 #   Hash of 'logging' config parameters.
+#
+# [*letsencrypt*]
+#   Default: undef
+#   Hash of 'letsencrypt' config parameters.
 #
 # [*logrotate*]
 #   Default: undef
@@ -374,6 +378,7 @@ class gitlab (
   $gitlab_rails = undef,
   $high_availability = undef,
   $logging = undef,
+  Optional[Hash] $letsencrypt = undef,
   $logrotate = undef,
   $manage_storage_directories = undef,
   $manage_accounts = undef,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -69,6 +69,20 @@ describe 'gitlab', type: :class do
               with_content(%r{^\s*nginx\['listen_port'\] = ('|)80('|)$})
           }
         end
+        describe 'letsencrypt' do
+          let(:params) do
+            { letsencrypt: {
+              'enable' => true,
+              'contact_emails' => ['test@example.com']
+            } }
+          end
+
+          it {
+            is_expected.to contain_file('/etc/gitlab/gitlab.rb'). \
+              with_content(%r{^\s*letsencrypt\['enable'\] = true$}).
+              with_content(%r{^\s*letsencrypt\['contact_emails'\] = \["test@example.com"\]$})
+          }
+        end
         describe 'secrets' do
           let(:params) do
             { secrets: {

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -193,6 +193,16 @@ nginx['<%= k -%>'] = <%= decorate(@nginx[k]) %>
 <%- @gitlab_workhorse.keys.sort.each do |k| -%>
 gitlab_workhorse['<%= k -%>'] = <%= decorate(@gitlab_workhorse[k]) %>
 <%- end end -%>
+<%- if @letsencrypt -%>
+
+######################
+# GitLab Letsencrypt #
+######################
+## see: https://docs.gitlab.com/omnibus/settings/ssl.html#let-39-s-encrypt-integration
+
+<%- @letsencrypt.keys.sort.each do |k| -%>
+letsencrypt['<%= k -%>'] = <%= decorate(@letsencrypt[k]) %>
+<%- end end -%>
 <%- if @logging -%>
 
 ##################


### PR DESCRIPTION
This small PR should be all that's needed to add basic support for the new (gitlab >= 10.5) letsencrypt support.
Please note spec tests are missing, since none of the other hash-based settings seem to have them either.


fixes #199 