### PR TITLE
Move backup to its own class

### DIFF
--- a/manifests/backup.pp
+++ b/manifests/backup.pp
@@ -1,0 +1,24 @@
+# == Class gitlab::backup
+#
+# This class is called from gitlab for backup config.
+#
+class gitlab::backup {
+  $rake_exec = $::gitlab::rake_exec
+  $backup_cron_enable = $::gitlab::backup_cron_enable
+  $backup_cron_minute = $::gitlab::backup_cron_minute
+  $backup_cron_hour = $::gitlab::backup_cron_hour
+  if empty($::gitlab::backup_cron_skips) {
+    $backup_cron_skips = ''
+  } else {
+    $_backup_cron_skips = join($::gitlab::backup_cron_skips, ',')
+    $backup_cron_skips = "SKIP=${_backup_cron_skips}"
+  }
+
+  if $backup_cron_enable {
+    cron {'gitlab backup':
+      command => "${rake_exec} gitlab:backup:create CRON=1 ${backup_cron_skips}",
+      hour    => $backup_cron_hour,
+      minute  => $backup_cron_minute,
+    }
+  }
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -74,15 +74,6 @@ class gitlab::config {
   $gitlab_workhorse = $::gitlab::gitlab_workhorse
   $user = $::gitlab::user
   $web_server = $::gitlab::web_server
-  $backup_cron_enable = $::gitlab::backup_cron_enable
-  $backup_cron_minute = $::gitlab::backup_cron_minute
-  $backup_cron_hour = $::gitlab::backup_cron_hour
-  if empty($::gitlab::backup_cron_skips) {
-    $backup_cron_skips = ''
-  } else {
-    $_backup_cron_skips = join($::gitlab::backup_cron_skips, ',')
-    $backup_cron_skips = "SKIP=${_backup_cron_skips}"
-  }
 
   # replicate $nginx to $mattermost_nginx if $mattermost_nginx_eq_nginx true
   if $mattermost_nginx_eq_nginx {
@@ -207,14 +198,6 @@ class gitlab::config {
       group  => 'git',
       mode   => '0650',
       source => 'puppet:///modules/gitlab/gitlab_shell_authorized_keys',
-    }
-  }
-
-  if $backup_cron_enable {
-    cron {'gitlab backup':
-      command => "${rake_exec} gitlab:backup:create CRON=1 ${backup_cron_skips}",
-      hour    => $backup_cron_hour,
-      minute  => $backup_cron_minute,
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -435,10 +435,12 @@ class gitlab (
   class { '::gitlab::install': }
   -> class { '::gitlab::config': }
   ~> class { '::gitlab::service': }
+  -> class { '::gitlab::backup': }
 
   contain gitlab::install
   contain gitlab::config
   contain gitlab::service
+  contain gitlab::backup
 
   $custom_hooks.each |$name, $options| {
     gitlab::custom_hook { $name:


### PR DESCRIPTION
This commit moves the backup cronjob to its own class. This ensures that
backup configuration changes do not trigger a Gitlab service restart.

Fixes #204.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
