### PR TITLE
remove git_data_dir

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,13 +17,7 @@ class gitlab::config {
   $geo_secondary_role = $::gitlab::geo_secondary_role
   $git = $::gitlab::git
   $gitaly = $::gitlab::gitaly
-  $git_data_dir = $::gitlab::git_data_dir
-  # git_data_dirs is the new way to specify data_dirs, introduced in 8.10
-  if $git_data_dir {
-    $git_data_dirs = merge({ 'default' => { 'path' => $::gitlab::git_data_dir} }, $::gitlab::git_data_dirs)
-  } else {
-    $git_data_dirs = $::gitlab::git_data_dirs
-  }
+  $git_data_dirs = $::gitlab::git_data_dirs
   $gitlab_git_http_server = $::gitlab::gitlab_git_http_server
   $gitlab_ci = $::gitlab::gitlab_ci
   $gitlab_pages = $::gitlab::gitlab_pages

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -145,21 +145,6 @@ class gitlab::config {
       logoutput   => true,
       tries       => 5,
     }
-
-    if $postgresql =~ Hash {
-      unless $postgresql[enable] {
-        exec { 'gitlab_setup':
-          command     => "/bin/echo yes | ${rake_exec} gitlab:setup",
-          refreshonly => true,
-          timeout     => 1800,
-          require     => Exec['gitlab_reconfigure'],
-          unless      => "/bin/grep complete ${git_data_dir}/postgresql.setup",
-        }
-        -> file { "${git_data_dir}/postgresql.setup":
-          content => 'complete',
-        }
-      }
-    }
   }
 
   if $skip_auto_migrations != undef {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,9 +115,9 @@
 #   Default: undef
 #   Hash of 'Gitaly' config parameters.
 #
-# [*git_data_dir*]
+# [*git_data_dirs*]
 #   Default: undef
-#   Git data dir
+#   Hash of git data directories
 #
 # [*gitlab_git_http_server*]
 #   Default: undef
@@ -376,7 +376,6 @@ class gitlab (
   Boolean                        $geo_secondary_role            = false,
   Optional[Hash]                 $git                           = undef,
   Optional[Hash]                 $gitaly                        = undef,
-  Optional[Stdlib::Absolutepath] $git_data_dir                  = undef,
   Optional[Hash]                 $git_data_dirs                 = undef,
   Optional[Hash]                 $gitlab_git_http_server        = undef,
   Optional[Hash]                 $gitlab_ci                     = undef,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -228,10 +228,13 @@ describe 'gitlab', type: :class do
               }
             }
           end
+          let(:expected_content) do
+            datadirs: %(git_data_dirs({\"default\"=>{\"path\"=>\"/git-data/data\"}})\n)
+          end
 
           it do
             is_expected.to contain_file('/etc/gitlab/gitlab.rb').
-              with_content(%r{^\s*git_data_dirs\(\{\"default\"\=\>\{\"path\"=>\"\/git-data\/data\"\}\})})
+              with_content(%r{\s*#{Regexp.quote(expected_content[:datadirs])}}m)
           end
         end
         describe 'with store_git_keys_in_db' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -229,7 +229,9 @@ describe 'gitlab', type: :class do
             }
           end
           let(:expected_content) do
-            datadirs: %(git_data_dirs({\"default\"=>{\"path\"=>\"/git-data/data\"}})\n)
+            {
+              datadirs: %(git_data_dirs({\"default\"=>{\"path\"=>\"/git-data/data\"}})\n)
+            }
           end
 
           it do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -222,23 +222,16 @@ describe 'gitlab', type: :class do
           let(:params) do
             {
               'git_data_dirs' => {
-                'default' => '/var/opt/gitlab/data',
-                'alt' => '/opt/data'
+                'default' => {
+                  'path' => '/git-data/data',
+                }
               }
             }
           end
 
           it do
             is_expected.to contain_file('/etc/gitlab/gitlab.rb').
-              with_content(%r{^\s*git_data_dirs\(\{\"alt\"\=\>\"\/opt\/data\"\,\s\"default\"=>\"\/var\/opt\/gitlab\/data\"\}\)})
-          end
-        end
-        describe 'without data_dirs' do
-          let(:params) { { git_data_dir: '/var/opt/data' } }
-
-          it do
-            is_expected.to contain_file('/etc/gitlab/gitlab.rb').
-              with_content(%r{"/var/opt/data"})
+              with_content(%r{^\s*git_data_dirs\(\{\"default\"\=\>\{\"path\"=>\"\/git-data\/data\"\}\})})
           end
         end
         describe 'with store_git_keys_in_db' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -223,7 +223,7 @@ describe 'gitlab', type: :class do
             {
               'git_data_dirs' => {
                 'default' => {
-                  'path' => '/git-data/data',
+                  'path' => '/git-data/data'
                 }
               }
             }

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -42,12 +42,6 @@ external_url '<%= @external_url %>'
 <%- if @external_port -%>
 external_port '<%= @external_port %>'
 <%- end -%>
-<%- if @git_data_dir -%>
-## For setting up different data storing directory
-## see https://gitlab.com/gitlab-org/omnibus-gitlab/blob/629def0a7a26e7c2326566f0758d4a27857b52a3/README.md#storing-git-data-in-an-alternative-directory
-## If you want to use a single non-default directory to store git data use:
-git_data_dir "<%= @git_data_dir %>"
-<%- end -%>
 <%- if @git_data_dirs -%>
 
 ### For setting up different data storing directory


### PR DESCRIPTION
- removed  and documented `git_data_dir` 
- removed the automatic execution of  `gitlab-rake gitlab:setup` if
service_manage = true and postgresql hash has configs but enable is undef || present.

Fixes #159  
Fixes #35  