### PR TITLE
remove auto-execution of gitlab:setup

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -145,21 +145,6 @@ class gitlab::config {
       logoutput   => true,
       tries       => 5,
     }
-
-    if $postgresql =~ Hash {
-      unless $postgresql[enable] {
-        exec { 'gitlab_setup':
-          command     => "/bin/echo yes | ${rake_exec} gitlab:setup",
-          refreshonly => true,
-          timeout     => 1800,
-          require     => Exec['gitlab_reconfigure'],
-          unless      => "/bin/grep complete ${git_data_dir}/postgresql.setup",
-        }
-        -> file { "${git_data_dir}/postgresql.setup":
-          content => 'complete',
-        }
-      }
-    }
   }
 
   if $skip_auto_migrations != undef {


### PR DESCRIPTION
This code block was valid in older versions of gitlab, but in 10.x versions, there are several situations where you would be managing the gitlab service _and_ had configurations in the `postgresql` hash, _and_ have postgresql disabled, or merely not indicate and let the default psql config for the `enable` setting be utilized by omnibus chef.  (for example, gitlab HA configurations for database roles/nodes, or when providing your own psql database)

Additionally, the `git_data_dir` is no longer a valid param, and the postgres configuration doesn't use teh `setup.complete` file at this path any more. This causes gitlab to re-perform setup on each puppet run if you have postgres configurations but don't explictly indicate `enable => true`

Fixes #35 
Fixes #195 