### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ prerequisits (f.e. Postfix). This module doesn't handle them, that's the job
 of the specific modules.
 
 It requires only the [puppetlabs-apt](https://forge.puppetlabs.com/puppetlabs/apt) module when using it under
-a Debian based OS and the paramater `manage_package_repo` is not false. Furthermore the `stdlib` module is required.
+a Debian based OS and the parameter `manage_package_repo` is not false. Furthermore the `stdlib` module is required.
 
 At least on RedHat based OS versions, it's required that Puppet is configured with
 the [`stringify_facts`](https://docs.puppetlabs.com/references/3.stable/configuration.html#stringifyfacts) setting set to `false` (Puppet < 4.0), otherwise


### PR DESCRIPTION

#### Pull Request (PR) description

Typo fix in the README.md,  'paramater' should be 'parameter'.
