### PR TITLE
Revert "Fix wrong quotation in boolean"

### DIFF
--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -31,11 +31,7 @@ def numify(obj)
 end
 
 def decorate(v)
-  if not ['true','false'].include?(v.to_s)
-    numify(v).inspect
-  else
-    v.to_s
-  end
+  numify(v).inspect
 end
 -%>
 


### PR DESCRIPTION
Reverts voxpupuli/puppet-gitlab#223

After some discussion in #225, I think it's best to expect valid data types be passed to the module. We could wind up with serious scope creep, and a very untrustworthy decorator, if we we try to program exceptions for non-valid data.

In addition, the original PR takes into consideration `'True'` and `'False'`, but not any other capitalized/cased form of those two words, meaning it only works in very specific circumstances.

Rather than add more exception handling to the decorator, I think it's best to keep the scope of the decorator limited to accepting valid puppet data types. (It should pass a `puppet validate` test).