### PR TITLE
Update auto migrations file

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,29 @@ class { 'gitlab':
 }
 ```
 
+### Skip Auto Reconfigure (formerly Skip Auto Migrations)
+
+In order to achieve [Zero Downtime Upgrades](https://docs.gitlab.com/omnibus/update/README.html#zero-downtime-updates)
+of your GitLab instance, GitLab will need to skip the post-install step of the omnibus package that automatically calls
+`gitlab-ctl reconfigure` for you. In GitLab < 10.5, GitLab check for the presence of a file at `/etc/gitlab/skip-auto-migrations`.
+As of GitLab `10.6`, this is deprecated, and you are warned to use `/etc/gitlab/skip-auto-reconfigure` going forward.
+
+Both of these are currently supported in this module, and you should be aware of which option is right for you
+based on the version of GitLab Omnibus you are running.  You will be presented with a deprecation notice in you
+puppet client if using the deprecated form.
+
+```puppet
+# use 'absent' or 'present' for the skip_auto_reconfigure param
+class { 'gitlab':
+  skip_auto_reconfigure => 'present'
+}
+
+# use true/false for the skip_auto_migrations param
+class { 'gitlab':
+  skip_auto_migrations => true
+}
+```
+
 ### Gitlab Custom Hooks
 
 Manage custom hook files within a GitLab project. Custom hooks can be created

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -61,7 +61,6 @@ class gitlab::config {
   $shell = $::gitlab::shell
   $sidekiq = $::gitlab::sidekiq
   $sidekiq_cluster = $::gitlab::sidekiq_cluster
-  $skip_auto_reconfigure = $::gitlab::skip_auto_reconfigure
   $store_git_keys_in_db = $::gitlab::store_git_keys_in_db
   $source_config_file = $::gitlab::source_config_file
   $unicorn = $::gitlab::unicorn
@@ -140,13 +139,6 @@ class gitlab::config {
       logoutput   => true,
       tries       => 5,
     }
-  }
-
-  file { '/etc/gitlab/skip-auto-reconfigure':
-    ensure => $skip_auto_reconfigure,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0644',
   }
 
   if $store_git_keys_in_db != undef {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -61,7 +61,7 @@ class gitlab::config {
   $shell = $::gitlab::shell
   $sidekiq = $::gitlab::sidekiq
   $sidekiq_cluster = $::gitlab::sidekiq_cluster
-  $skip_auto_migrations = $::gitlab::skip_auto_migrations
+  $skip_auto_reconfigure = $::gitlab::skip_auto_migrations
   $store_git_keys_in_db = $::gitlab::store_git_keys_in_db
   $source_config_file = $::gitlab::source_config_file
   $unicorn = $::gitlab::unicorn
@@ -142,17 +142,11 @@ class gitlab::config {
     }
   }
 
-  if $skip_auto_migrations != undef {
-    $_skip_auto_migrations_ensure = $skip_auto_migrations ? {
-      true    => 'present',
-      default => 'absent',
-    }
-    file { '/etc/gitlab/skip-auto-migrations':
-      ensure => $_skip_auto_migrations_ensure,
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0644',
-    }
+  file { '/etc/gitlab/skip-auto-reconfigure':
+    ensure => $skip_auto_reconfigure,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
   }
 
   if $store_git_keys_in_db != undef {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -61,7 +61,7 @@ class gitlab::config {
   $shell = $::gitlab::shell
   $sidekiq = $::gitlab::sidekiq
   $sidekiq_cluster = $::gitlab::sidekiq_cluster
-  $skip_auto_reconfigure = $::gitlab::skip_auto_migrations
+  $skip_auto_reconfigure = $::gitlab::skip_auto_reconfigure
   $store_git_keys_in_db = $::gitlab::store_git_keys_in_db
   $source_config_file = $::gitlab::source_config_file
   $unicorn = $::gitlab::unicorn

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -449,6 +449,8 @@ class gitlab (
   contain gitlab::service
   contain gitlab::backup
 
+  Class['gitlab::preinstall'] -> Class['gitlab::install'] -> Class['gitlab::config'] ~> Class['gitlab::service'] -> Class['gitlab::backup']
+
   $custom_hooks.each |$name, $options| {
     gitlab::custom_hook { $name:
       * => $options,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -281,9 +281,10 @@
 #   Default: undef
 #   Hash of 'sidekiq_cluster' config parameters.
 #
-# [*skip_auto_migrations*]
-#   Default: undef
-#   Enable or disable auto migrations. undef keeps the current state on the system.
+# [*skip_auto_reconfigure*]
+#   Default: 'absent'
+#   String containing either 'present' or 'absent'
+#   Utilized for Zero Downtime Updates, See: https://docs.gitlab.com/omnibus/update/README.html#zero-downtime-updates
 #
 # [*store_git_keys_in_db*]
 #   Default: false
@@ -422,7 +423,7 @@ class gitlab (
   Optional[Hash]                 $shell                         = undef,
   Optional[Hash]                 $sidekiq                       = undef,
   Optional[Hash]                 $sidekiq_cluster               = undef,
-  Optional[Boolean]              $skip_auto_migrations          = undef,
+  Enum['present', 'absent']      $skip_auto_reconfigure         = 'absent',
   Optional[Stdlib::Absolutepath] $source_config_file            = undef,
   Boolean                        $store_git_keys_in_db          = false,
   Optional[Hash]                 $unicorn                       = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -281,9 +281,13 @@
 #   Default: undef
 #   Hash of 'sidekiq_cluster' config parameters.
 #
+# [*skip_auto_migrations*]
+#   Default: undef
+#   Deprecated if using Gitlab > 10.6.4 and < 11.0.0, unsupported by gitlab omnibus using gitlab 11+
+#   Use skip_auto_reconfigure
+#
 # [*skip_auto_reconfigure*]
-#   Default: 'absent'
-#   String containing either 'present' or 'absent'
+#   Default: undef
 #   Utilized for Zero Downtime Updates, See: https://docs.gitlab.com/omnibus/update/README.html#zero-downtime-updates
 #
 # [*store_git_keys_in_db*]
@@ -333,8 +337,8 @@
 # === Examples
 #
 #  class { 'gitlab':
-#    edition           => 'ee',
-#    external_url      => 'https://gitlab.mydomain.tld',
+#    edition                                       => 'ee',
+#    external_url                                  => 'https://gitlab.mydomain.tld',
 #    nginx             => { redirect_http_to_https => true },
 #  }
 #
@@ -424,6 +428,7 @@ class gitlab (
   Optional[Hash]                 $sidekiq                       = undef,
   Optional[Hash]                 $sidekiq_cluster               = undef,
   Enum['present', 'absent']      $skip_auto_reconfigure         = 'absent',
+  Optional                       $skip_auto_migrations          = undef,
   Optional[Stdlib::Absolutepath] $source_config_file            = undef,
   Boolean                        $store_git_keys_in_db          = false,
   Optional[Hash]                 $unicorn                       = undef,
@@ -438,11 +443,7 @@ class gitlab (
   Hash                           $global_hooks                  = {},
 ) inherits gitlab::params {
 
-  class { '::gitlab::install': }
-  -> class { '::gitlab::config': }
-  ~> class { '::gitlab::service': }
-  -> class { '::gitlab::backup': }
-
+  contain gitlab::preinstall
   contain gitlab::install
   contain gitlab::config
   contain gitlab::service

--- a/manifests/preinstall.pp
+++ b/manifests/preinstall.pp
@@ -1,0 +1,34 @@
+class gitlab::preinstall (
+  $skip_auto_migrations = $gitlab::skip_auto_migrations,
+  $skip_auto_reconfigure = $gitlab::skip_auto_reconfigure
+) {
+
+  ####
+  # Deprecation notice:
+  # skip_auto_migrations is deprecated and will be removed at some point after
+  # GitLab 11.0 is released
+	$skip_auto_migrations_deprecation_msg = "DEPRECTATION: 'skip_auto_migrations' is deprecated if using GitLab 10.6 or greater. Set skip_auto_reconfigure instead"
+
+  if $skip_auto_migrations != undef {
+
+		notify { $skip_auto_migrations_deprecation_msg: }
+
+    $_skip_auto_migrations_ensure = $skip_auto_migrations ? {
+      true    => 'present',
+      default => 'absent',
+    }
+    file { '/etc/gitlab/skip-auto-migrations':
+      ensure => $_skip_auto_migrations_ensure,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0644',
+    }
+  }
+
+  file { '/etc/gitlab/skip-auto-reconfigure':
+    ensure => $skip_auto_reconfigure,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0644',
+  }
+}

--- a/manifests/preinstall.pp
+++ b/manifests/preinstall.pp
@@ -11,16 +11,17 @@ class gitlab::preinstall (
   # Deprecation notice:
   # skip_auto_migrations is deprecated and will be removed at some point after
   # GitLab 11.0 is released
-	$skip_auto_migrations_deprecation_msg = "DEPRECTATION: 'skip_auto_migrations' is deprecated if using GitLab 10.6 or greater. Set skip_auto_reconfigure instead"
+  $skip_auto_migrations_deprecation_msg = "DEPRECTATION: 'skip_auto_migrations' is deprecated if using GitLab 10.6 or greater. Set skip_auto_reconfigure instead"
 
   if $skip_auto_migrations != undef {
 
-		notify { $skip_auto_migrations_deprecation_msg: }
+    notify { $skip_auto_migrations_deprecation_msg: }
 
     $_skip_auto_migrations_ensure = $skip_auto_migrations ? {
       true    => 'present',
       default => 'absent',
     }
+
     file { '/etc/gitlab/skip-auto-migrations':
       ensure => $_skip_auto_migrations_ensure,
       owner  => 'root',

--- a/manifests/preinstall.pp
+++ b/manifests/preinstall.pp
@@ -1,3 +1,7 @@
+# == Class gitlab::config
+#
+# This class is for setting pre-install configurations
+#
 class gitlab::preinstall (
   $skip_auto_migrations = $gitlab::skip_auto_migrations,
   $skip_auto_reconfigure = $gitlab::skip_auto_reconfigure

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-gitlab",
-  "version": "2.0.1-rc0",
+  "version": "3.0.0-rc0",
   "author": "Vox Pupuli",
   "summary": "Installation and configuration of Gitlab Omnibus",
   "license": "BSD-3-Clause",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -84,10 +84,9 @@ describe 'gitlab', type: :class do
           }
         end
         describe 'skip_auto_reconfigure' do
-          let(:params) do
-            { { skip_auto_reconfigure: 'present' } }
+          let(:params) { { skip_auto_reconfigure => 'present' } }
 
-            it {
+          it {
               is_expected.to contain_file('/etc/gitlab/skip-auto-reconfigure').with({
                 'ensure' => 'present',
                 'owner' => 'root',
@@ -95,7 +94,6 @@ describe 'gitlab', type: :class do
                 'mode' => '0644',
               })
             }
-          end
         end
         describe 'secrets' do
           let(:params) do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -84,7 +84,7 @@ describe 'gitlab', type: :class do
           }
         end
         describe 'skip_auto_reconfigure' do
-          let(:params) { { skip_auto_reconfigure => 'present' } }
+          let(:params) { { skip_auto_reconfigure: 'present' } }
 
           it {
               is_expected.to contain_file('/etc/gitlab/skip-auto-reconfigure').with({

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -87,12 +87,12 @@ describe 'gitlab', type: :class do
           let(:params) { { skip_auto_reconfigure: 'present' } }
 
           it {
-              is_expected.to contain_file('/etc/gitlab/skip-auto-reconfigure').with(
-                'ensure' => 'present',
-                'owner' => 'root',
-                'group' => 'root',
-                'mode' => '0644'
-              )
+            is_expected.to contain_file('/etc/gitlab/skip-auto-reconfigure').with(
+              'ensure' => 'present',
+              'owner' => 'root',
+              'group' => 'root',
+              'mode' => '0644'
+            )
           }
         end
         describe 'secrets' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -87,13 +87,13 @@ describe 'gitlab', type: :class do
           let(:params) { { skip_auto_reconfigure: 'present' } }
 
           it {
-              is_expected.to contain_file('/etc/gitlab/skip-auto-reconfigure').with({
+              is_expected.to contain_file('/etc/gitlab/skip-auto-reconfigure').with(
                 'ensure' => 'present',
                 'owner' => 'root',
                 'group' => 'root',
-                'mode' => '0644',
-              })
-            }
+                'mode' => '0644'
+              )
+          }
         end
         describe 'secrets' do
           let(:params) do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -83,6 +83,20 @@ describe 'gitlab', type: :class do
               with_content(%r{^\s*letsencrypt\['contact_emails'\] = \["test@example.com"\]$})
           }
         end
+        describe 'skip_auto_reconfigure' do
+          let(:params) do
+            { { skip_auto_reconfigure: 'present' } }
+
+            it {
+              is_expected.to contain_file('/etc/gitlab/skip-auto-reconfigure').with({
+                'ensure' => 'present',
+                'owner' => 'root',
+                'group' => 'root',
+                'mode' => '0644',
+              })
+            }
+          end
+        end
         describe 'secrets' do
           let(:params) do
             { secrets: {


### PR DESCRIPTION
Adds support for managing package post-install steps via the pre-install configuration of a `/etc/gitlab/skip-auto-reconfigure` file (replacing the deprecated `/etc/gitlab/skip-auto-migrations`.

- created an additional manifest for `preinstall.pp`, to handle configurations that need to be present prior to the package installation process. 
- Added documentation to README.md for usage of both the new `skip_auto_reconfigure` class parameter, and the deprecated `skip_auto_migrations` parameter. 
- added a `notify` resource if using the `skip_auto_migrations` parameter to let users know of the deprecation.

Closes #228, #232 