### PR TITLE
Do not manage apt-transport-https.

### DIFF
--- a/manifests/cirunner.pp
+++ b/manifests/cirunner.pp
@@ -72,7 +72,6 @@ class gitlab::cirunner (
     case $::osfamily {
       'Debian': {
         include apt
-        ensure_packages('apt-transport-https')
 
         apt::source { 'apt_gitlabci':
           comment  => 'GitlabCI Runner Repo',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -16,7 +16,6 @@ class gitlab::install {
     case $::osfamily {
       'debian': {
         include apt
-        ensure_packages('apt-transport-https')
 
         apt::source { "gitlab_official_${edition}":
           comment  => 'Official repository for Gitlab',

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": ">=2.1.0 <5.0.0"
+      "version_requirement": ">=4.4.0 <5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Hi,

since apt-transport-https is in Ubuntu 18.04/Debian 10 just a transitional package it isn't mandatory anymore, the apt-transport-https dependency should be conditional.

Since [puppetlabs-apt](https://github.com/puppetlabs/puppetlabs-apt/blob/master/manifests/source.pp#L32) 4.4.0 handle this correctly I prefer to consume that logic instead build a own.

See:

https://packages.ubuntu.com/bionic/apt-transport-https
https://packages.debian.org/buster/apt-transport-https