### PR TITLE
remove authors, copyright, examples from init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -326,22 +326,6 @@
 #   valid values: db, uploads, repositories, builds,
 #                 artifacts, lfs, registry, pages
 #
-# === Examples
-#
-#  class { 'gitlab':
-#    edition                                       => 'ee',
-#    external_url                                  => 'https://gitlab.mydomain.tld',
-#    nginx             => { redirect_http_to_https => true },
-#  }
-#
-# === Authors
-#
-# Tobias Brunner <tobias.brunner@vshn.ch>
-#
-# === Copyright
-#
-# Copyright 2015 Tobias Brunner, VSHN AG
-#
 class gitlab (
   # package installation handling
   Boolean                        $manage_package_repo           = $::gitlab::params::manage_package_repo,


### PR DESCRIPTION
Looks like we missed some of the docs in the comment data of `manifests/init.pp` when we migrated vrom VSHN to voxpupuli.  This PR just removes the old/outdated Authors, Copyright, and examples blocks from the class definition documentation in `manifests/init.pp`