### PR TITLE
Add gitlab-consul auth for pgbouncer database

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,31 @@ You will need to configure the AuthorizedKeysCommand for the `git` user in sshd.
 Instructions for this are provided by GitLab at
 [Fast lookup of authorized SSH keys in the databasse](https://docs.gitlab.com/ee/administration/operations/fast_ssh_key_lookup.html)
 
+### Setting up GitLab HA
+
+#### pgbouncer Authentication
+
+For use in HA configurations, or when using postgres replication in a single-node setup, this module supports automated configuration
+of pgbouncer authentication. To set this up, set `pgpass_file_ensure => 'present'` and provide a valid value for `pgbouncer_password`.
+
+```puppet
+class {'gitlab':
+  pgpass_file_ensure => 'present',
+  pgbouncer_password => 'YourPassword'
+}
+```
+
+By default, this creates a file at `/home/gitlab-consul/.pgpass`, which gitlab uses to authenticate to the pgbouncer database as the
+`gitlab-consul` _database_ user. This _does not_ refer to the `gitlab-consul` system user. The location of the `.pgpass` file can
+be changed based on how you manage homedirs or based on your utilization of NFS. This location should be set to be the home
+directory you have configured for the `gitlab-consul` system user.
+
+```puppet
+class {'gitlab':
+  pgpass_file_location => '/homedir/for/gitlab-consul-system-user/.pgpass'
+}
+```
+
 ### Gitlab CI Runner Limitations
 
 The Gitlab CI runner installation is at the moment only tested on Ubuntu 14.04.

--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -1,0 +1,5 @@
+gitlab::pgpass_file_attrs:
+  ensure: 'absent'
+  path: '/home/gitlab-consul/.pgpass'
+  owner: 'gitlab-consul'
+  group: 'gitlab-consul'

--- a/data/defaults.yaml
+++ b/data/defaults.yaml
@@ -1,5 +1,0 @@
-gitlab::pgpass_file_attrs:
-  ensure: 'absent'
-  path: '/home/gitlab-consul/.pgpass'
-  owner: 'gitlab-consul'
-  group: 'gitlab-consul'

--- a/manifests/host_config.pp
+++ b/manifests/host_config.pp
@@ -12,6 +12,8 @@ class gitlab::host_config (
   $skip_auto_migrations = $gitlab::skip_auto_migrations,
   $skip_auto_reconfigure = $gitlab::skip_auto_reconfigure,
   $store_git_keys_in_db = $gitlab::store_git_keys_in_db,
+  $pgpass_file_attrs = $gitlab::pgpass_file_attrs,
+  $pgbouncer_password = $gitlab::pgbouncer_password,
 ) {
 
   file { $config_dir:
@@ -75,6 +77,15 @@ class gitlab::host_config (
       mode   => '0650',
       source => 'puppet:///modules/gitlab/gitlab_shell_authorized_keys',
     }
+  }
+
+  unless ($pgpass_file_attrs[ensure] == 'present' and empty($pgbouncer_password)){
+    file { "pgpass":
+      *       => $pgpass_file_attrs,
+      content => template('gitlab/.pgpass.erb'),
+    }
+  } else {
+    fail('A password must be provided to $pgbouncer_password if $pgpass_file_attrs[ensure] = "present"')
   }
 
   include gitlab::backup

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -316,7 +316,6 @@
 #                 artifacts, lfs, registry, pages
 #
 class gitlab (
-  Hash                           $pgpass_file_attrs,
   # package configuration
   String                         $package_ensure                  = 'installed',
   Optional[String]               $edition                         = undef,
@@ -363,6 +362,8 @@ class gitlab (
   Optional[Hash]                 $node_exporter                   = undef,
   Optional[Hash]                 $redis_exporter                  = undef,
   Optional[String]               $pgbouncer_password              = undef,
+  Enum['absent', 'present']      $pgpass_file_ensure              = 'absent',
+  Stdlib::Absolutepath           $pgpass_file_location            = '/home/gitlab-consul/.pgpass',
   Optional[Hash]                 $postgres_exporter               = undef,
   Optional[Hash]                 $gitlab_monitor                  = undef,
   Optional[String]               $pages_external_url              = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -316,6 +316,7 @@
 #                 artifacts, lfs, registry, pages
 #
 class gitlab (
+  Hash                           $pgpass_file_attrs,
   # package configuration
   String                         $package_ensure                  = 'installed',
   Optional[String]               $edition                         = undef,
@@ -361,6 +362,7 @@ class gitlab (
   Optional[Hash]                 $nginx                           = undef,
   Optional[Hash]                 $node_exporter                   = undef,
   Optional[Hash]                 $redis_exporter                  = undef,
+  Optional[String]               $pgbouncer_password              = undef,
   Optional[Hash]                 $postgres_exporter               = undef,
   Optional[Hash]                 $gitlab_monitor                  = undef,
   Optional[String]               $pages_external_url              = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -315,6 +315,21 @@
 #   valid values: db, uploads, repositories, builds,
 #                 artifacts, lfs, registry, pages
 #
+# [*pgpass_file_location*]
+#   Default: '/home/gitlab-consul/.pgpass'
+#   Path to location of .pgpass file used by consul to
+#   authenticate with pgbouncer database
+#
+# [*pgpass_file_ensure*]
+#   Default: 'absent'
+#   Create .pgpass file for pgbouncer authentication
+#   When set to present requires valid value for pgbouncer_password
+#
+# [*pgbouncer_password*]
+#   Default: undef
+#   Password for the gitlab-consul database user in the
+#   pgbouncer database
+#
 class gitlab (
   # package configuration
   String                         $package_ensure                  = 'installed',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -105,6 +105,34 @@ describe 'gitlab', type: :class do
             is_expected.to contain_exec('gitlab_reconfigure').with_environment(['SKIP_POST_DEPLOYMENT_MIGRATIONS=true'])
           }
         end
+        context 'managing pgpass_file' do
+          describe 'with defaults' do
+            it { is_expected.to contain_file('/home/gitlab-consul/.pgpass').with_ensure('absent') }
+          end
+          context "with pgpass_file_ensure => 'present'" do
+            let(:params) do
+              { pgpass_file_ensure: 'present' }
+            end
+
+            describe 'without a password for pgbouncer_password' do
+              it { is_expected.to raise_error(%r{A password must be provided to pgbouncer_password}) }
+            end
+            describe 'with a password for pgbouncer_password' do
+              let(:params) do
+                super().merge('pgbouncer_password' => 'PAsswd')
+              end
+
+              it {
+                is_expected.to contain_file('/home/gitlab-consul/.pgpass').with(
+                  'ensure' => 'present',
+                  'path' => '/home/gitlab-consul/.pgpass',
+                  'owner' => 'gitlab-consul',
+                  'group' => 'gitlab-consul'
+                )
+              }
+            end
+          end
+        end
         describe 'gitlab_rails with hash value' do
           let(:params) do
             { gitlab_rails: {

--- a/templates/.pgpass.erb
+++ b/templates/.pgpass.erb
@@ -1,0 +1,1 @@
+127.0.0.1:*:pgbouncer:pgbouncer:<%= @pgbouncer_password -%>


### PR DESCRIPTION
This enhancement allows for the configuration of the authentication required for enabling built in database failover/service discovery. This PR adds configuration for the file the gitlab-omnibus package uses to authenticate the service discovery agent (consul) against the pgbouncer database.

closes #229 