### PR TITLE
Allow configuration of the alertmanager via puppet.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,10 @@
 #   Default: /etc/gitlab/gitlab.rb
 #   Path of the Gitlab Omnibus config file.
 #
+# [*alertmanager*]
+#   Default: undef
+#   Hash of 'alertmanager' config parameters.
+#
 # [*ci_redis*]
 #   Default: undef
 #   Hash of 'ci_redis' config parameters.
@@ -364,6 +368,7 @@ class gitlab (
   String                         $service_group                   = 'root',
   # gitlab specific
   String                         $rake_exec                       = '/usr/bin/gitlab-rake',
+  Optional[Hash]                 $alertmanager                    = undef,
   Optional[Hash]                 $ci_redis                        = undef,
   Optional[Hash]                 $ci_unicorn                      = undef,
   Boolean                        $config_manage                   = true,

--- a/manifests/omnibus_config.pp
+++ b/manifests/omnibus_config.pp
@@ -8,6 +8,7 @@ class gitlab::omnibus_config (
 ){
 
   # get variables from the toplevel manifest for usage in the template
+  $alertmanager = $gitlab::alertmanager
   $ci_redis = $gitlab::ci_redis
   $ci_unicorn = $gitlab::ci_unicorn
   $external_url = $gitlab::external_url

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -70,6 +70,20 @@ describe 'gitlab', type: :class do
               with_content(%r{^\s*nginx\['listen_port'\] = ('|)80('|)$})
           }
         end
+        describe 'alertmanager' do
+          let(:params) do
+            { alertmanager: {
+              'enable' => true,
+              'flags' => { 'cluster.advertise-address' => '127.0.0.1:9093' }
+            } }
+          end
+
+          it {
+            is_expected.to contain_file('/etc/gitlab/gitlab.rb'). \
+              with_content(%r{^\s*alertmanager\['enable'\] = true$}).
+              with_content(%r{^\s*alertmanager\['flags'\] = {\"cluster.advertise-address\"=>\"127.0.0.1:9093\"}$})
+          }
+        end
         describe 'letsencrypt' do
           let(:params) do
             { letsencrypt: {

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -335,6 +335,15 @@ redis_exporter['<%= k -%>'] = <%= decorate(@redis_exporter[k]) %>
 <%- @postgres_exporter.keys.sort.each do |k| -%>
 postgres_exporter['<%= k -%>'] = <%= decorate(@postgres_exporter[k]) %>
 <%- end end -%>
+<%- if @alertmanager -%>
+
+################################################################################
+## Alertmanager
+##! Docs: https://prometheus.io/docs/alerting/alertmanager/
+
+<%- @alertmanager.keys.sort.each do |k| -%>
+alertmanager['<%= k -%>'] = <%= decorate(@alertmanager[k]) %>
+<%- end end -%>
 <%- if @gitlab_monitor -%>
 
 ################################################################################


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds support for configuring the Alertmanager gitlab service.
Documentation for that service is still quite sparse, best I've come across is:
https://prometheus.io/docs/alerting/alertmanager/

Right now our gitlab server is perpetually in error due to an unconfigured alertmanager,
and there's no way to disable it (this commit adds that).

Disabling alertmanager via hiera:
```
gitlab::alertmanager:
  enable: false
```

#### This Pull Request (PR) fixes the following issues
Fixes #266 

Couldn't find any unit tests for other params like this, so I haven't included them here either.
Please let me know :)