### PR TITLE
 fix repositories missing the edition name

### DIFF
--- a/data/Debian.yaml
+++ b/data/Debian.yaml
@@ -1,8 +1,14 @@
 gitlab::repository_configuration:
   'apt::source':
-    "gitlab_official_%{lookup('gitlab::edition')}":
+    "gitlab_official_ce":
       comment: 'Official repository for GitLab Omnibus'
-      location: "https://packages.gitlab.com/gitlab/gitlab-%{lookup('gitlab::edition')}/debian"
+      location: "https://packages.gitlab.com/gitlab/gitlab-ce/debian"
+      key:
+        id: '1A4C919DB987D435939638B914219A96E15E78F4'
+        source: 'https://packages.gitlab.com/gpg.key'
+    "gitlab_official_ee":
+      comment: 'Official repository for GitLab Omnibus'
+      location: "https://packages.gitlab.com/gitlab/gitlab-ee/debian"
       key:
         id: '1A4C919DB987D435939638B914219A96E15E78F4'
         source: 'https://packages.gitlab.com/gpg.key'

--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -1,10 +1,19 @@
 gitlab::repository_configuration:
   yumrepo:
-    "gitlab_official_%{lookup('gitlab::edition')}":
+    "gitlab_official_ce":
       ensure: 'present'
       assumeyes: true
       enabled: 1
-      baseurl: "https://packages.gitlab.com/gitlab/gitlab-%{lookup('gitlab::edition')}/el/%{facts.os.release.major}/$basearch"
+      baseurl: "https://packages.gitlab.com/gitlab/gitlab-ce/el/%{facts.os.release.major}/$basearch"
+      gpgkey: "https://packages.gitlab.com/gpg.key"
+      gpgcheck: 1
+      repo_gpgcheck: 1
+      sslverify: 1
+    "gitlab_official_ee":
+      ensure: 'present'
+      assumeyes: true
+      enabled: 1
+      baseurl: "https://packages.gitlab.com/gitlab/gitlab-ee/el/%{facts.os.release.major}/$basearch"
       gpgkey: "https://packages.gitlab.com/gpg.key"
       gpgcheck: 1
       repo_gpgcheck: 1

--- a/manifests/omnibus_package_repository.pp
+++ b/manifests/omnibus_package_repository.pp
@@ -18,36 +18,7 @@ class gitlab::omnibus_package_repository (
       $_edition = $manage_upstream_edition
     }
 
-    # ensure the correct edition is used if upstream package repositories are being configured
-    if $_edition != 'disabled'{
-      case $facts['os']['family'] {
-        'Debian': {
-          $_filtered_repository_configuration = {
-            'apt::source' => {
-              "gitlab_official_${_edition}" => {
-                location => "https://packages.gitlab.com/gitlab/gitlab-${_edition}/debian",
-              },
-            },
-          }
-        }
-        'RedHat': {
-          $_filtered_repository_configuration = {
-            'yumrepo' =>  {
-              "gitlab_official_${_edition}" =>  {
-                baseurl => "https://packages.gitlab.com/gitlab/gitlab-${_edition}/el/${facts['os']['release']['major']}/\$basearch",
-              },
-            },
-          }
-        }
-        default: {
-          $_filtered_repository_configuration = {}
-        }
-      }
-      $_repository_configuration = deep_merge($repository_configuration, $_filtered_repository_configuration)
-    } else {
-    # using upstream repository, so just use defaults
-      $_repository_configuration = $repository_configuration
-    }
+    $_repository_configuration = $repository_configuration
 
     # common attributes for all repository configuration resources
     # ensures correct ordering regardless of the number or configuration

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -21,9 +21,11 @@ describe 'gitlab', type: :class do
 
         case facts[:osfamily]
         when 'Debian'
-          it { is_expected.to contain_apt__source('gitlab_official_ce') }
+          it { is_expected.to contain_apt__source('gitlab_official_ce').with_comment(%r{.}) }
+          it { is_expected.not_to contain_apt__source('gitlab_official_') }
         when 'RedHat'
-          it { is_expected.to contain_yumrepo('gitlab_official_ce') }
+          it { is_expected.to contain_yumrepo('gitlab_official_ce').with_enabled(1) }
+          it { is_expected.not_to contain_yumrepo('gitlab_official_') }
         end
       end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -21,11 +21,15 @@ describe 'gitlab', type: :class do
 
         case facts[:osfamily]
         when 'Debian'
-          it { is_expected.to contain_apt__source('gitlab_official_ce').with_comment(%r{.}) }
+          it { is_expected.to contain_apt__source('gitlab_official_ce').with_ensure('present').with_comment(%r{.}) }
+          it { is_expected.to contain_apt__source('gitlab_official_ee').with_ensure('absent') }
           it { is_expected.not_to contain_apt__source('gitlab_official_') }
+          it { is_expected.not_to contain_yumrepo('gitlab_official_ce') }
         when 'RedHat'
-          it { is_expected.to contain_yumrepo('gitlab_official_ce').with_enabled(1) }
+          it { is_expected.to contain_yumrepo('gitlab_official_ce').with_ensure('present').with_enabled(1) }
+          it { is_expected.to contain_yumrepo('gitlab_official_ee').with_ensure('absent') }
           it { is_expected.not_to contain_yumrepo('gitlab_official_') }
+          it { is_expected.not_to contain_apt__source('gitlab_official_ce') }
         end
       end
 
@@ -37,9 +41,11 @@ describe 'gitlab', type: :class do
 
           case facts[:osfamily]
           when 'Debian'
-            it { is_expected.to contain_apt__source('gitlab_official_ee') }
+            it { is_expected.to contain_apt__source('gitlab_official_ee').with_ensure('present') }
+            it { is_expected.to contain_apt__source('gitlab_official_ce').with_ensure('absent')  }
           when 'RedHat'
-            it { is_expected.to contain_yumrepo('gitlab_official_ee') }
+            it { is_expected.to contain_yumrepo('gitlab_official_ee').with_ensure('present') }
+            it { is_expected.to contain_yumrepo('gitlab_official_ce').with_ensure('absent')  }
           end
         end
         describe 'external_url' do


### PR DESCRIPTION
The current `master` branch would generate a `gitlab_official_` repository with an invalid URL. Basically, all edition names (ce/ee) were missing in the repository configuration.

The root of the issue was the attempt at accessing the Puppet catalog's `gitlab::edition` from Hiera. This can't work AFAIK unless users are instructed to only configure the classes through Hiera (undesirable IMO).

I fixed it by providing both CE/EE definitions in Hiera and adding the `ensure` attribute in Puppet to match the requested edition. By managing both repositories, this also ensures that the user cannot end up with a leftover. NB: the Puppet data manipulation step is uglier than it should be, by lack of a Hash -> Hash map function.

The first commit documents the bug, should you prefer a different solution.