### PR TITLE
Update gpgkey for yum repos

### DIFF
--- a/data/RedHat.yaml
+++ b/data/RedHat.yaml
@@ -5,7 +5,7 @@ gitlab::repository_configuration:
       assumeyes: true
       enabled: 1
       baseurl: "https://packages.gitlab.com/gitlab/gitlab-%{lookup('gitlab::edition')}/el/%{facts.os.release.major}/$basearch"
-      gpgkey: "https://packages.gitlab.com/gpg.key"
+      gpgkey: "https://packages.gitlab.com/gitlab/gitlab-%{lookup('gitlab::edition')}/gpgkey https://packages.gitlab.com/gitlab/gitlab-%{lookup('gitlab::edition')}/gpgkey/gitlab-gitlab-%{lookup('gitlab::edition')}-3D645A26AB9FBD22.pub.gpg"
       gpgcheck: 1
       repo_gpgcheck: 1
       sslverify: 1


### PR DESCRIPTION
This updates the `gpgkey` line of the yum repositories as per Gitlab's install docs. At the moment, the `master` branch fails to install because of this. 

The first three commits are PR #271, 227abb5 is the only relevant change here.

I'll rebase this PR if needed when #271 is updated.