### PR TITLE
fix the repositories as per #271 and #272

### DIFF
--- a/data/family/RedHat.yaml
+++ b/data/family/RedHat.yaml
@@ -5,7 +5,7 @@ gitlab::repository_configuration:
       assumeyes: true
       enabled: 1
       baseurl: "https://packages.gitlab.com/gitlab/gitlab-ce/el/%{facts.os.release.major}/$basearch"
-      gpgkey: "https://packages.gitlab.com/gpg.key"
+      gpgkey: "https://packages.gitlab.com/gitlab/gitlab-ce/gpgkey https://packages.gitlab.com/gitlab/gitlab-ce/gpgkey/gitlab-gitlab-ce-3D645A26AB9FBD22.pub.gpg"
       gpgcheck: 1
       repo_gpgcheck: 1
       sslverify: 1
@@ -13,8 +13,8 @@ gitlab::repository_configuration:
       ensure: 'present'
       assumeyes: true
       enabled: 1
-      baseurl: "https://packages.gitlab.com/gitlab/gitlab-%{lookup('gitlab::edition')}/el/%{facts.os.release.major}/$basearch"
-      gpgkey: "https://packages.gitlab.com/gitlab/gitlab-%{lookup('gitlab::edition')}/gpgkey https://packages.gitlab.com/gitlab/gitlab-%{lookup('gitlab::edition')}/gpgkey/gitlab-gitlab-%{lookup('gitlab::edition')}-3D645A26AB9FBD22.pub.gpg"
+      baseurl: "https://packages.gitlab.com/gitlab/gitlab-ee/el/%{facts.os.release.major}/$basearch"
+      gpgkey: "https://packages.gitlab.com/gitlab/gitlab-ee/gpgkey https://packages.gitlab.com/gitlab/gitlab-ee/gpgkey/gitlab-gitlab-ee-3D645A26AB9FBD22.pub.gpg"
       gpgcheck: 1
       repo_gpgcheck: 1
       sslverify: 1

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -35,6 +35,9 @@ describe 'gitlab', type: :class do
           end
         when 'RedHat'
           it { is_expected.to contain_yumrepo('gitlab_official_ce').with_ensure('present').with_enabled(1) }
+          it { is_expected.to contain_yumrepo('gitlab_official_ce').without_baseurl(%r{/gitlab-/}) }
+          it { is_expected.to contain_yumrepo('gitlab_official_ce').without_gpgkey(%r{/gitlab-/}) }
+          it { is_expected.to contain_yumrepo('gitlab_official_ce').without_gpgkey('https://packages.gitlab.com/gpg.key') }
           it { is_expected.to contain_yumrepo('gitlab_official_ee').with_ensure('absent') }
           it { is_expected.not_to contain_yumrepo('gitlab_official_') }
           it { is_expected.not_to contain_apt__source('gitlab_official_ce') }
@@ -53,7 +56,10 @@ describe 'gitlab', type: :class do
             it { is_expected.to contain_apt__source('gitlab_official_ce').with_ensure('absent')  }
           when 'RedHat'
             it { is_expected.to contain_yumrepo('gitlab_official_ee').with_ensure('present') }
-            it { is_expected.to contain_yumrepo('gitlab_official_ce').with_ensure('absent')  }
+            it { is_expected.to contain_yumrepo('gitlab_official_ee').without_baseurl(%r{/gitlab-/}) }
+            it { is_expected.to contain_yumrepo('gitlab_official_ee').without_gpgkey(%r{/gitlab-/}) }
+            it { is_expected.to contain_yumrepo('gitlab_official_ee').without_gpgkey('https://packages.gitlab.com/gpg.key') }
+            it { is_expected.to contain_yumrepo('gitlab_official_ce').with_ensure('absent') }
           end
         end
         describe 'external_url' do


### PR DESCRIPTION
Somehow, after the #271 and #272 merges we ended up without the GPG key change for gitlab-ce and with `%{lookup()}` calls left in gitlab-ee. This commit fixes the data and adds tests for it.