### PR TITLE
do not require service if it's not being managed

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -18,6 +18,7 @@ class gitlab::service (
     $start = "${service_exec} start"
     $stop = "${service_exec} stop"
     $status = "${service_exec} status"
+    $reconfigure_attributes_require = [Service[$service_name], Class['gitlab::install']]
 
     service { $service_name:
       ensure     => $service_ensure,
@@ -29,6 +30,8 @@ class gitlab::service (
       hasstatus  => true,
       hasrestart => true,
     }
+  } else {
+    $reconfigure_attributes_require = Class['gitlab::install']
   }
 
   $reconfigure_attributes = {
@@ -38,13 +41,12 @@ class gitlab::service (
     logoutput   => true,
     tries       => 5,
     subscribe   => Class['gitlab::omnibus_config'],
-    require     => [Service[$service_name], Class['gitlab::install']],
   }
 
   if $skip_post_deployment_migrations {
-    $_reconfigure_attributes = $reconfigure_attributes + { environment => ['SKIP_POST_DEPLOYMENT_MIGRATIONS=true'] }
+    $_reconfigure_attributes = $reconfigure_attributes + { environment => ['SKIP_POST_DEPLOYMENT_MIGRATIONS=true'], require => $reconfigure_attributes_require }
   } else {
-    $_reconfigure_attributes = $reconfigure_attributes
+    $_reconfigure_attributes = $reconfigure_attributes + { require => $reconfigure_attributes_require }
   }
 
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -12,7 +12,7 @@ describe 'gitlab', type: :class do
         it { is_expected.to contain_class('gitlab::omnibus_config').that_comes_before('Class[gitlab::install]') }
         it { is_expected.to contain_class('gitlab::install').that_comes_before('Class[gitlab::service]') }
         it { is_expected.to contain_class('gitlab::service') }
-        it { is_expected.to contain_exec('gitlab_reconfigure').that_subscribes_to('Class[gitlab::omnibus_config]') }
+        it { is_expected.to contain_exec('gitlab_reconfigure').that_subscribes_to('Class[gitlab::omnibus_config]').that_requires(['Service[gitlab-runsvdir]', 'Class[gitlab::install]']) }
         it { is_expected.to contain_file('/etc/gitlab/gitlab.rb') }
         it { is_expected.to contain_service('gitlab-runsvdir') }
         it { is_expected.to contain_package('gitlab-omnibus').with_ensure('installed').with_name('gitlab-ce') }
@@ -358,6 +358,15 @@ describe 'gitlab', type: :class do
 
           it do
             is_expected.to contain_file('/opt/gitlab-shell/authorized_keys')
+          end
+        end
+        describe 'service_manage = false' do
+          let(:params) { { service_manage: false } }
+
+          it do
+            is_expected.to contain_class('gitlab::service')
+            is_expected.not_to contain_service('gitlab-runsvdir')
+            is_expected.to contain_exec('gitlab_reconfigure').that_requires('Class[gitlab::install]')
           end
         end
       end


### PR DESCRIPTION
#### Pull Request (PR) description
Set appropriate value for the _require_ parameter of the _gitlab_reconfigure_ exec resource depending on whether the service is being managed.

#### This Pull Request (PR) fixes the following issues
Dependency error when _gitlab::service::service_manage_ is set to _false_

>  Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Could not find resource 'Service[gitlab-runsvdir]' in parameter 'require' (file: /etc/puppetlabs/code/environments/production/external_modules/gitlab/manifests/service.pp, line: 58) on node gitlab.local