### PR TITLE
Allow to set numeric values as string

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -302,6 +302,22 @@ describe 'gitlab', type: :class do
               with_content(%r{^\s*mattermost_external_url 'https:\/\/mattermost\.myserver\.tld'$})
           }
         end
+        describe 'mattermost with env value' do
+          let(:params) do
+            {
+              mattermost: {
+                env: {
+                  'MM_EMAILSETTINGS_SMTPPORT' => '25'
+                }
+              }
+            }
+          end
+
+          it {
+            is_expected.to contain_file('/etc/gitlab/gitlab.rb'). \
+              with_content(%r{^mattermost\['env'\] = {"MM_EMAILSETTINGS_SMTPPORT"=>"25"}$})
+          }
+        end
         describe 'mattermost with hash value' do
           let(:params) do
             { mattermost: {

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -18,20 +18,18 @@ def sort_hash_by_key(hash, deep=true, &block)
   end
 end
 
-def numify(obj)
-  if obj.is_a?(String)
-    Integer(obj) rescue Float(obj) rescue obj
-  elsif obj.is_a?(Array)
-    obj.map { |item| numify(item) }
+def walk(obj)
+  if obj.is_a?(Array)
+    obj.map { |item| walk(item) }
   elsif obj.is_a?(Hash)
-    sort_hash_by_key(obj.merge(obj) { |_, v| numify(v) })
+    sort_hash_by_key(obj.merge(obj) { |_, v| walk(v) })
   else
     obj
   end
 end
 
 def decorate(v)
-  numify(v).inspect
+  walk(v).inspect
 end
 -%>
 


### PR DESCRIPTION
#### Pull Request (PR) description
When the user sets a value to the string representation of a number (e.g. `"25"`), the current code turn this into the number itself (`25` in this case).

#### This Pull Request (PR) fixes the following issues
Fixes #289
