### PR TITLE
Ensure yumrepo contains description

### DIFF
--- a/data/family/RedHat.yaml
+++ b/data/family/RedHat.yaml
@@ -2,6 +2,7 @@ gitlab::repository_configuration:
   yumrepo:
     "gitlab_official_ce":
       ensure: 'present'
+      descr: 'gitlab_gitlab-ce'
       assumeyes: true
       enabled: 1
       baseurl: "https://packages.gitlab.com/gitlab/gitlab-ce/el/%{facts.os.release.major}/$basearch"
@@ -11,6 +12,7 @@ gitlab::repository_configuration:
       sslverify: 1
     "gitlab_official_ee":
       ensure: 'present'
+      descr: 'gitlab_gitlab-ee'
       assumeyes: true
       enabled: 1
       baseurl: "https://packages.gitlab.com/gitlab/gitlab-ee/el/%{facts.os.release.major}/$basearch"


### PR DESCRIPTION
Signed-off-by: Clément Parisot <clement.parisot@uni.lu>

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
When using this module under Redhat/Centos, the yum repo configuration file doesn't contain any "name" field. It generates some warnings for example when using yum-cron to update the packages:

```
/etc/cron.hourly/0yum-hourly.cron:

Repository 'gitlab_official_ee' is missing name in configuration, using id
```
On `yum-repo`puppet resource, *name* is addressed as [*descr* parameter](https://puppet.com/docs/puppet/5.4/types/yumrepo.html#yumrepo-attribute-descr). I chose to put the default value that we find when installing Gitlab from the official CE and EE repositories: `gitlab_gitlab-ce` and `gitlab_gitlab-ee`.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
I haven't opened any issue to report this problem.