### PR TITLE
Fix typo

### DIFF
--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -1,5 +1,5 @@
 ## THIS CONFIGURATION IS MANAGED BY PUPPET
-# for all possible paramters, see:
+# for all possible parameters, see:
 # https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/files/gitlab-config-template/gitlab.rb.template
 <%-
 # As this template is writing a config file based on some hashes and hashes are not meant to be in a certain order,


### PR DESCRIPTION
"paramters" should be "parameters"

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

I've fixed a typo in the gitlab.rb.erb template.

#### This Pull Request (PR) fixes the following issues

n/a

