### PR TITLE
Deprecate gitlab_monitor in favour of gitlab_exporter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -190,7 +190,12 @@
 #
 # [*gitlab_monitor*]
 #   Default: undef
+#   Deprecated if using Gitlab > 12.3 and < 13.0, unsupported by gitlab omnibus using Gitlab 13+
 #   Hash of 'gitlab_monitor' config parameters.
+#
+# [*gitlab_exporter*]
+#   Default: undef
+#   Hash of 'gitlab_exporter' config parameters.
 #
 # [*pages_external_url*]
 #   Default: undef
@@ -417,6 +422,7 @@ class gitlab (
   Stdlib::Absolutepath           $pgpass_file_location            = '/home/gitlab-consul/.pgpass',
   Optional[Hash]                 $postgres_exporter               = undef,
   Optional[Hash]                 $gitlab_monitor                  = undef,
+  Optional[Hash]                 $gitlab_exporter                 = undef,
   Optional[String]               $package_name                    = undef,
   Optional[String]               $pages_external_url              = undef,
   Optional[Hash]                 $pages_nginx                     = undef,

--- a/manifests/omnibus_config.pp
+++ b/manifests/omnibus_config.pp
@@ -41,6 +41,7 @@ class gitlab::omnibus_config (
   $redis_exporter = $gitlab::redis_exporter
   $postgres_exporter = $gitlab::postgres_exporter
   $gitlab_monitor = $gitlab::gitlab_monitor
+  $gitlab_exporter = $gitlab::gitlab_exporter
   $pages_external_url = $gitlab::pages_external_url
   $pages_nginx = $gitlab::pages_nginx
   $pages_nginx_eq_nginx = $gitlab::pages_nginx_eq_nginx
@@ -90,6 +91,11 @@ class gitlab::omnibus_config (
     $_real_registry_nginx = $nginx
   } else {
     $_real_registry_nginx = $registry_nginx
+  }
+
+  # Throw deprecation warning if gitlab_monitor is used
+  if $gitlab_monitor {
+    notify { "DEPRECTATION: 'gitlab_monitor' is deprecated if using GitLab 12.3 or greater. Set 'gitlab_exporter' instead": }
   }
 
   # attributes shared by all config files used by omnibus package

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -377,6 +377,33 @@ describe 'gitlab', type: :class do
             is_expected.to contain_file('/opt/gitlab-shell/authorized_keys')
           end
         end
+        describe 'gitlab_monitor' do
+          let(:params) do
+            { gitlab_monitor: {
+              'enable' => true
+            } }
+          end
+
+          it {
+            is_expected.to contain_file('/etc/gitlab/gitlab.rb'). \
+              with_content(%r{^\s*gitlab_monitor\['enable'\] = true$})
+          }
+          it {
+            is_expected.to contain_notify("DEPRECTATION: 'gitlab_monitor' is deprecated if using GitLab 12.3 or greater. Set 'gitlab_exporter' instead")
+          }
+        end
+        describe 'gitlab_exporter' do
+          let(:params) do
+            { gitlab_exporter: {
+              'enable' => true
+            } }
+          end
+
+          it {
+            is_expected.to contain_file('/etc/gitlab/gitlab.rb'). \
+              with_content(%r{^\s*gitlab_exporter\['enable'\] = true$})
+          }
+        end
       end
     end
   end

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -353,6 +353,15 @@ alertmanager['<%= k -%>'] = <%= decorate(@alertmanager[k]) %>
 <%- @gitlab_monitor.keys.sort.each do |k| -%>
 gitlab_monitor['<%= k -%>'] = <%= decorate(@gitlab_monitor[k]) %>
 <%- end end -%>
+<%- if @gitlab_exporter -%>
+
+################################################################################
+## Prometheus Gitlab exporter
+##! Docs: https://docs.gitlab.com/ce/administration/monitoring/prometheus/gitlab_exporter.html
+
+<%- @gitlab_exporter.keys.sort.each do |k| -%>
+gitlab_exporter['<%= k -%>'] = <%= decorate(@gitlab_exporter[k]) %>
+<%- end end -%>
 <%- if @high_availability -%>
 
 


### PR DESCRIPTION
#### Pull Request (PR) description
The `gitlab_monitor` parameter is deprecated for Gitlab > 12.3 and will be removed in 13. This adds the new `gitlab_exporter` parameter.

#### This Pull Request (PR) fixes the following issues
Fixes #323.
