### PR TITLE
Use new gitlab gpg keys for package management

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ class { 'gitlab':
         'comment' => 'Internal mirror of upstream gitlab package repository',
         'location' => 'https://my.internal.url/repository/packages.gitlab.com/gitlab/gitlab-ce/debian',
         'key' => {
-          'id' => '1A4C919DB987D435939638B914219A96E15E78F4',
+          'id' => 'F6403F6544A38863DAA0B6E03F01618A51312F3F',
           'source' => 'https://my.internal.url/repository/package.gitlab.com/gpg.key'
         }
       },

--- a/data/family/Debian.yaml
+++ b/data/family/Debian.yaml
@@ -4,11 +4,11 @@ gitlab::repository_configuration:
       comment: 'Official repository for GitLab Omnibus'
       location: "https://packages.gitlab.com/gitlab/gitlab-ce/debian"
       key:
-        id: '1A4C919DB987D435939638B914219A96E15E78F4'
+        id: 'F6403F6544A38863DAA0B6E03F01618A51312F3F'
         source: 'https://packages.gitlab.com/gpg.key'
     "gitlab_official_ee":
       comment: 'Official repository for GitLab Omnibus'
       location: "https://packages.gitlab.com/gitlab/gitlab-ee/debian"
       key:
-        id: '1A4C919DB987D435939638B914219A96E15E78F4'
+        id: 'F6403F6544A38863DAA0B6E03F01618A51312F3F'
         source: 'https://packages.gitlab.com/gpg.key'

--- a/data/family/RedHat.yaml
+++ b/data/family/RedHat.yaml
@@ -1,3 +1,4 @@
+# From: https://packages.gitlab.com/install/repositories/gitlab/gitlab-ce/config_file.repo?os=centos&dist=7&source=script
 gitlab::repository_configuration:
   yumrepo:
     "gitlab_official_ce":

--- a/data/os/Ubuntu.yaml
+++ b/data/os/Ubuntu.yaml
@@ -4,11 +4,11 @@ gitlab::repository_configuration:
       comment: 'Official repository for GitLab Omnibus'
       location: "https://packages.gitlab.com/gitlab/gitlab-ce/ubuntu"
       key:
-        id: '1A4C919DB987D435939638B914219A96E15E78F4'
+        id: 'F6403F6544A38863DAA0B6E03F01618A51312F3F'
         source: 'https://packages.gitlab.com/gpg.key'
     "gitlab_official_ee":
       comment: 'Official repository for GitLab Omnibus'
       location: "https://packages.gitlab.com/gitlab/gitlab-ee/ubuntu"
       key:
-        id: '1A4C919DB987D435939638B914219A96E15E78F4'
+        id: 'F6403F6544A38863DAA0B6E03F01618A51312F3F'
         source: 'https://packages.gitlab.com/gpg.key'


### PR DESCRIPTION
#### Pull Request (PR) description
As document in https://docs.gitlab.com/omnibus/update/package_signatures gitlab gpg keys expire soon and needs to be replace with new one.

The old key is valid until 2020-04-15 while is new keys starts at 2020-04-06.

A release of this module in this time slot should useful to avoid some local breaking changes.

This PR is created at 2020-03-28. I except test failures until 2020-04-06.
