### PR TITLE
Fix gitlab-ctl reconfigure LD_LIBRARY_PATH warning

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -35,7 +35,7 @@ class gitlab::service (
   }
 
   $reconfigure_attributes = {
-    command     => '/usr/bin/gitlab-ctl reconfigure',
+    command     => '/bin/sh -c "unset LD_LIBRARY_PATH; /usr/bin/gitlab-ctl reconfigure"',
     refreshonly => true,
     timeout     => 1800,
     logoutput   => true,

--- a/spec/acceptance/gitlab_spec.rb
+++ b/spec/acceptance/gitlab_spec.rb
@@ -9,7 +9,12 @@ describe 'gitlab class' do
       }
       EOS
 
-      apply_manifest(pp, catch_failures: true)
+      result = apply_manifest(pp, catch_failures: true)
+
+      # gitlab-ctl reconfigure emits a warning if the LD_LIBRARY_PATH
+      # is set, even if it is empty.
+      expect(result.stdout).not_to match(%r{LD_LIBRARY_PATH was found})
+
       apply_manifest(pp, catch_changes: true)
 
       shell('sleep 15') # give it some time to start up


### PR DESCRIPTION
#### Pull Request (PR) description

This patch ensures LD_LIBRARY_PATH is unset in the `gitlab-ctl configure`
`exec` resource.

#### This Pull Request (PR) fixes the following issues

Fixes the LD_LIBRARY_PATH warning emitted at the end of `gitlab-ctl reconfigure`.

As shown in https://travis-ci.org/github/voxpupuli/puppet-gitlab/jobs/739916738
on lines 2089-2090, `gitlab-ctl reconfigure` emits a warning when LD_LIBRARY_PATH
is set. It emits this warning even if that environment variable is empty.  Since
LD_LIBRARY_PATH is always set by the Puppet wrapper script used in the `puppet`
CLI, the `exec` that runs `gitlab-ctl configure` must unset this variable to
avoid the warning message.