### PR TITLE
Add missing (required) name value for yum repo

### DIFF
--- a/data/family/RedHat.yaml
+++ b/data/family/RedHat.yaml
@@ -5,6 +5,7 @@ gitlab::repository_configuration:
   yumrepo:
     "gitlab_official_ce":
       ensure: 'present'
+      descr: 'gitlab-ce'
       assumeyes: true
       enabled: 1
       baseurl: "https://packages.gitlab.com/gitlab/gitlab-ce/el/%{facts.os.release.major}/$basearch"
@@ -14,6 +15,7 @@ gitlab::repository_configuration:
       sslverify: 1
     "gitlab_official_ee":
       ensure: 'present'
+      descr: 'gitlab-ee'
       assumeyes: true
       enabled: 1
       baseurl: "https://packages.gitlab.com/gitlab/gitlab-ee/el/%{facts.os.release.major}/$basearch"


### PR DESCRIPTION
## Pull Request (PR) description

Add the required name attribute to the yum/dnf repo

#### This Pull Request (PR) fixes the following issues

```
Repository 'gitlab_official_ee' is missing name in configuration, using id.
```