### PR TITLE
Add support for geo_logcursor options in gitlab.rb

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,7 @@
 # @param external_url External URL of Gitlab.
 # @param external_port External PORT of Gitlab.
 # @param geo_postgresql Hash of 'geo_postgresql' config parameters.
+# @param geo_logcursor Hash of 'geo_logcursor' config parameters.
 # @param geo_primary_role Boolean to enable Geo primary role
 # @param geo_secondary Hash of 'geo_secondary' config parameters.
 # @param geo_secondary_role Boolean to enable Geo secondary role
@@ -117,6 +118,7 @@ class gitlab (
   Stdlib::Httpurl                   $external_url                    = "http://${facts['networking']['fqdn']}",
   Optional[Integer[1, 65565]]       $external_port                   = undef,
   Optional[Hash]                    $geo_postgresql                  = undef,
+  Optional[Hash]                    $geo_logcursor                   = undef,
   Boolean                           $geo_primary_role                = false,
   Optional[Hash]                    $geo_secondary                   = undef,
   Boolean                           $geo_secondary_role              = false,

--- a/manifests/omnibus_config.pp
+++ b/manifests/omnibus_config.pp
@@ -14,6 +14,7 @@ class gitlab::omnibus_config (
   $external_url = $gitlab::external_url
   $external_port = $gitlab::external_port
   $geo_postgresql = $gitlab::geo_postgresql
+  $geo_logcursor = $gitlab::geo_logcursor
   $geo_primary_role = $gitlab::geo_primary_role
   $geo_secondary = $gitlab::geo_secondary
   $geo_secondary_role = $gitlab::geo_secondary_role

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -446,6 +446,18 @@ describe 'gitlab', type: :class do
               with_content(%r{^\s*pgbouncer_exporter\['enable'\] = true$})
           }
         end
+        describe 'geo_logcursor' do
+          let(:params) do
+            { geo_logcursor: {
+              'enable' => true
+            } }
+          end
+
+          it {
+            is_expected.to contain_file('/etc/gitlab/gitlab.rb'). \
+              with_content(%r{^\s*geo_logcursor\['enable'\] = true$})
+          }
+        end
       end
     end
   end

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -554,6 +554,18 @@ geo_secondary['<%= k -%>'] = <%= decorate(@geo_secondary[k]) %>
 <%- @geo_postgresql.keys.sort.each do |k| -%>
 geo_postgresql['<%= k -%>'] = <%= decorate(@geo_postgresql[k]) %>
 <%- end end -%>
+<%- if @geo_logcursor -%>
+
+########################
+# Gitlab Geo Log Cursor#
+########################
+## To configure GitLab Geo Log Cursor.
+## https://docs.gitlab.com/ee/development/geo.html#geo-log-cursor-daemon
+## https://docs.gitlab.com/ee/administration/geo/replication/multiple_servers.html#step-3-configure-the-tracking-database-on-the-secondary-node
+
+<%- @geo_logcursor.keys.sort.each do |k| -%>
+geo_logcursor['<%= k -%>'] = <%= decorate(@geo_logcursor[k]) %>
+<%- end end -%>
 <%- if @pgbouncer -%>
 ################################################################################
 # Pgbouncer (EE only)


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add support got `geo_logcursor` options in gitlab.rb, see:
https://docs.gitlab.com/ee/development/geo.html#geo-log-cursor-daemon
https://docs.gitlab.com/ee/administration/geo/replication/multiple_servers.html#step-3-configure-the-tracking-database-on-the-secondary-node

#### This Pull Request (PR) fixes the following issues
n/a
