### PR TITLE
Add support for the gitlab_kas configuration hash.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -258,6 +258,14 @@ Hash of 'gitlab_ci' config parameters.
 
 Default value: ``undef``
 
+
+##### `gitlab_kas`
+
+Data type: `Optional[Hash]`
+
+Hash of 'gitlab_kas' config parameters.
+
+Default value: ``undef``
 ##### `gitlab_pages`
 
 Data type: `Optional[Hash]`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,7 @@
 # @param git_data_dirs Hash of git data directories
 # @param gitlab_git_http_server Hash of 'gitlab_git_http_server' config parameters.
 # @param gitlab_ci Hash of 'gitlab_ci' config parameters.
+# @param gitlab_kas Hash of 'gitlab_kas' config parameters.
 # @param gitlab_pages Hash of 'gitlab_pages' config parameters.
 # @param gitlab_rails Hash of 'gitlab_pages' config parameters.
 # @param gitlab_workhorse Hash of 'gitlab_workhorse' config parameters.
@@ -128,6 +129,7 @@ class gitlab (
   Optional[Hash]                      $git_data_dirs                   = undef,
   Optional[Hash]                      $gitlab_git_http_server          = undef,
   Optional[Hash]                      $gitlab_ci                       = undef,
+  Optional[Hash]                      $gitlab_kas                      = undef,
   Optional[Hash]                      $gitlab_pages                    = undef,
   Optional[Hash]                      $gitlab_rails                    = undef,
   Optional[Hash]                      $grafana                         = undef,

--- a/manifests/omnibus_config.pp
+++ b/manifests/omnibus_config.pp
@@ -23,6 +23,7 @@ class gitlab::omnibus_config (
   $git_data_dirs = $gitlab::git_data_dirs
   $gitlab_git_http_server = $gitlab::gitlab_git_http_server
   $gitlab_ci = $gitlab::gitlab_ci
+  $gitlab_kas = $gitlab::gitlab_kas
   $gitlab_pages = $gitlab::gitlab_pages
   $gitlab_rails = $gitlab::gitlab_rails
   $grafana = $gitlab::grafana

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -293,6 +293,16 @@ registry['<%= k -%>'] = <%= decorate(@registry[k]) %>
 <%- @gitlab_ci.keys.sort.each do |k| -%>
 gitlab_ci['<%= k -%>'] = <%= decorate(@gitlab_ci[k]) %>
 <%- end end -%>
+<%- if @grafana -%>
+
+##############
+# GitLab KAS #
+##############
+## see: gitlab kubernetes-agent settings
+
+<%- @gitlab_kas.keys.sort.each do |k| -%>
+gitlab_kas['<%= k -%>'] = <%= decorate(@gitlab_kas[k]) %>
+<%- end end -%>
 <%- if @ci_unicorn -%>
 
 #####################

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -293,7 +293,7 @@ registry['<%= k -%>'] = <%= decorate(@registry[k]) %>
 <%- @gitlab_ci.keys.sort.each do |k| -%>
 gitlab_ci['<%= k -%>'] = <%= decorate(@gitlab_ci[k]) %>
 <%- end end -%>
-<%- if @grafana -%>
+<%- if @gitlab_kas -%>
 
 ##############
 # GitLab KAS #


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add support for the gitlab_kas configuration hash. (Kubernetes Agent Server).

#### This Pull Request (PR) fixes the following issues
gives the ability to configure "Kubernetes Agent Server" on gitlab-ee to manges Gitlab K8s agents.

Gitlab KAS: https://docs.gitlab.com/ee/administration/clusters/kas.html
Available configuration parameters: https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/files/gitlab-config-template/gitlab.rb.template#L1658
