### PR TITLE
Ensure apt::update is run before installing Gitlab

### DIFF
--- a/manifests/omnibus_package_repository.pp
+++ b/manifests/omnibus_package_repository.pp
@@ -54,6 +54,9 @@ class gitlab::omnibus_package_repository (
 
     # create all the repository resources
     $_repository_configuration.each() | String $resource_type, Hash $resources | {
+      if downcase($resource_type) == 'apt::source' {
+        Class['Apt::Update'] -> Class['gitlab::install']
+      }
       create_resources($resource_type, $resources, $resource_defaults)
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -22,6 +22,7 @@ describe 'gitlab', type: :class do
         when 'Debian'
           it { is_expected.to contain_apt__source('gitlab_official_ce').with_ensure('present').with_comment(%r{.}) }
           it { is_expected.to contain_apt__source('gitlab_official_ee').with_ensure('absent') }
+          it { is_expected.to contain_class('apt::update').that_comes_before('Class[gitlab::install]') }
           it { is_expected.not_to contain_apt__source('gitlab_official_') }
           it { is_expected.not_to contain_yumrepo('gitlab_official_ce') }
           case facts[:operatingsystem]
@@ -40,6 +41,7 @@ describe 'gitlab', type: :class do
           it { is_expected.to contain_yumrepo('gitlab_official_ee').with_ensure('absent') }
           it { is_expected.not_to contain_yumrepo('gitlab_official_') }
           it { is_expected.not_to contain_apt__source('gitlab_official_ce') }
+          it { is_expected.not_to contain_class('apt::update').that_comes_before('Class[gitlab::install]') }
         end
       end
 
@@ -53,6 +55,7 @@ describe 'gitlab', type: :class do
           when 'Debian'
             it { is_expected.to contain_apt__source('gitlab_official_ee').with_ensure('present') }
             it { is_expected.to contain_apt__source('gitlab_official_ce').with_ensure('absent')  }
+            it { is_expected.to contain_class('apt::update').that_comes_before('Class[gitlab::install]') }
           when 'RedHat'
             it { is_expected.to contain_yumrepo('gitlab_official_ee').with_ensure('present') }
             it { is_expected.to contain_yumrepo('gitlab_official_ee').without_baseurl(%r{/gitlab-/}) }


### PR DESCRIPTION
#### Pull Request (PR) description
This PR ensures that apt::update is run before installing Gitlab. Otherwise the installation will fail with `E: Unable to locate package gitlab-(ce|ee)`

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
