### PR TITLE
Add option to disable output of config diff

### DIFF
--- a/manifests/host_config.pp
+++ b/manifests/host_config.pp
@@ -7,6 +7,7 @@
 # @param pgpass_file_ensure Create .pgpass file for pgbouncer authentication. When set to present requires valid value for pgbouncer_password.
 # @param pgpass_file_location Path to location of .pgpass file used by consul to authenticate with pgbouncer database
 # @param pgbouncer_password Password for the gitlab-consul database user in the pgbouncer database
+# @param config_show_diff Whether to display diff in the puppet log or not
 class gitlab::host_config (
   $config_dir = '/etc/gitlab',
   $skip_auto_migrations = $gitlab::skip_auto_migrations,

--- a/manifests/host_config.pp
+++ b/manifests/host_config.pp
@@ -15,6 +15,7 @@ class gitlab::host_config (
   $pgpass_file_ensure = $gitlab::pgpass_file_ensure,
   $pgpass_file_location = $gitlab::pgpass_file_location,
   $pgbouncer_password = $gitlab::pgbouncer_password,
+  $config_show_diff = $gitlab::config_show_diff,
 ) {
   file { $config_dir:
     ensure => 'directory',
@@ -87,10 +88,11 @@ class gitlab::host_config (
   } else {
     # owner,group params for pgpass_file should NOT be changed, as they are hardcoded into gitlab HA db schema for pgbouncer database template
     file { $pgpass_file_location:
-      ensure  => $pgpass_file_ensure,
-      owner   => 'gitlab-consul',
-      group   => 'gitlab-consul',
-      content => epp('gitlab/.pgpass.epp', {
+      ensure    => $pgpass_file_ensure,
+      owner     => 'gitlab-consul',
+      group     => 'gitlab-consul',
+      show_diff => $config_show_diff,
+      content   => epp('gitlab/.pgpass.epp', {
           'pgbouncer_password' => $pgbouncer_password,
       }),
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@
 # @param manage_upstream_edition One of [ 'ce', 'ee', 'disabled' ]. Manage the installation of an upstream Gitlab Omnibus edition to install.
 # @param config_manage Should Puppet manage the config?
 # @param config_file Path of the Gitlab Omnibus config file.
+# @param config_show_diff Whether show the diff in the log or not.
 # @param alertmanager Hash of 'alertmanager' config parameters.
 # @param ci_redis Hash of 'ci_redis' config parameters.
 # @param ci_unicorn Hash of 'ci_unicorn' config parameters.
@@ -114,6 +115,7 @@ class gitlab (
   Optional[Hash]                      $ci_unicorn                      = undef,
   Boolean                             $config_manage                   = true,
   Stdlib::Absolutepath                $config_file                     = '/etc/gitlab/gitlab.rb',
+  Boolean                             $config_show_diff                = true,
   Optional[Hash]                      $consul                          = undef,
   Stdlib::Absolutepath                $custom_hooks_dir                = '/opt/gitlab/embedded/service/gitlab-shell/hooks',
   Stdlib::Absolutepath                $system_hooks_dir                = '/opt/gitlab/embedded/service/gitlab-rails/file_hooks',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,7 +115,7 @@ class gitlab (
   Optional[Hash]                      $ci_unicorn                      = undef,
   Boolean                             $config_manage                   = true,
   Stdlib::Absolutepath                $config_file                     = '/etc/gitlab/gitlab.rb',
-  Boolean                             $config_show_diff                = true,
+  Boolean                             $config_show_diff                = false,
   Optional[Hash]                      $consul                          = undef,
   Stdlib::Absolutepath                $custom_hooks_dir                = '/opt/gitlab/embedded/service/gitlab-shell/hooks',
   Stdlib::Absolutepath                $system_hooks_dir                = '/opt/gitlab/embedded/service/gitlab-rails/file_hooks',

--- a/manifests/omnibus_config.pp
+++ b/manifests/omnibus_config.pp
@@ -2,6 +2,7 @@
 #
 # @param config_manage Should Puppet manage the config?
 # @param config_file Path of the Gitlab Omnibus config file.
+# @param config_show_diff Whether to display diff in the puppet log or not
 class gitlab::omnibus_config (
   $config_manage = $gitlab::config_manage,
   $config_file = $gitlab::config_file,

--- a/manifests/omnibus_config.pp
+++ b/manifests/omnibus_config.pp
@@ -4,7 +4,8 @@
 # @param config_file Path of the Gitlab Omnibus config file.
 class gitlab::omnibus_config (
   $config_manage = $gitlab::config_manage,
-  $config_file = $gitlab::config_file
+  $config_file = $gitlab::config_file,
+  $config_show_diff = $gitlab::config_show_diff,
 ) {
   # get variables from the toplevel manifest for usage in the template
   $alertmanager = $gitlab::alertmanager
@@ -104,10 +105,11 @@ class gitlab::omnibus_config (
 
   # attributes shared by all config files used by omnibus package
   $config_file_attributes = {
-    ensure => 'present',
-    owner  => $service_user,
-    group  => $service_group,
-    mode   => '0600',
+    ensure    => 'present',
+    owner     => $service_user,
+    group     => $service_group,
+    mode      => '0600',
+    show_diff => $config_show_diff,
   }
 
   if $config_manage {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -190,6 +190,17 @@ describe 'gitlab', type: :class do
               with_content(%r{^\s*repmgr\['enable'\] = true$})
           }
         end
+        describe 'config_show_diff' do
+          let(:params) do
+            { config_show_diff: false }
+          end
+
+          it {
+            is_expected.to contain_file('/etc/gitlab/gitlab.rb').with(
+              'show_diff' => false
+            )
+          }
+        end
         describe 'skip_auto_reconfigure' do
           let(:params) { { skip_auto_reconfigure: 'present' } }
 
@@ -238,6 +249,29 @@ describe 'gitlab', type: :class do
                   %r{^127.0.0.1:\*:pgbouncer:pgbouncer:PAsswd}
                 )
               }
+            end
+            context 'with config_show_diff to false' do
+              let(:params) do
+                super().merge('config_show_diff' => false)
+              end
+
+              describe 'with a password for pgbouncer_password' do
+                let(:params) do
+                  super().merge('pgbouncer_password' => 'PAsswd')
+                end
+
+                it {
+                  is_expected.to contain_file('/home/gitlab-consul/.pgpass').with(
+                    'ensure' => 'present',
+                    'path' => '/home/gitlab-consul/.pgpass',
+                    'owner' => 'gitlab-consul',
+                    'group' => 'gitlab-consul',
+                    'show_diff' => false
+                  ).with_content(
+                    %r{^127.0.0.1:\*:pgbouncer:pgbouncer:PAsswd}
+                  )
+                }
+              end
             end
           end
         end


### PR DESCRIPTION
#### Pull Request (PR) description
I configure my authentication through `azure_activedirectory_v2`, and I don’t want my `client_secret` to be displayed in clear in the puppet logs.

Converting the `gitlab.rb.erb` to `.epp` so it supports the `sensitive` type would probably be cleaner, but I did not have success with it.  So this PR add option to disable output of the diff for sensitive information

```puppet
class example {
  class { 'gitlab' :
    [...]
    config_show_diff => false,
  }
}
```

I’ve included the option to also affect the file containing `$pgbouncer_password`, as it is sensitive information.  Is it is already a `epp` template, it could support `sensitive` type, but as I did not convert to the `sensitive` type elsewhere, it seemed simpler this way.

Feel free to comment if I missed anything.

#### This Pull Request (PR) fixes the following issues
Fixes #363 
