### PR TITLE
Improve support for hooks in `@hashed` storage

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -16,8 +16,8 @@
 
 ### Defined types
 
-* [`gitlab::custom_hook`](#gitlab--custom_hook): Manage custom hook files within a GitLab project.
-* [`gitlab::global_hook`](#gitlab--global_hook): Manage global chain loaded hook files for all GitLab projects.
+* [`gitlab::custom_hook`](#gitlab--custom_hook): Manage custom hook files within a GitLab project. Custom hooks can be created as a pre-receive, post-receive, or update hook. Only one of each is currently supported by this module.
+* [`gitlab::global_hook`](#gitlab--global_hook): Manage global chain loaded hook files for all GitLab projects. Hooks can be created as a pre-receive, post-receive, or update hook. It's possible to create  multipe hooks per type as long as their names are unique. Support for chained (global) hooks is introduced in GitLab Shell 4.1.0 and GitLab 8.15.
 * [`gitlab::system_hook`](#gitlab--system_hook): A file hook will run on each event so it's up to you to filter events or projects
 
 ### Tasks
@@ -1185,8 +1185,7 @@ Default value: `$gitlab::skip_post_deployment_migrations`
 
 ### <a name="gitlab--custom_hook"></a>`gitlab::custom_hook`
 
-Custom hooks can be created as a pre-receive, post-receive, or update hook.
-It is possible to create different custom hook types for the same project - one each for pre-receive, post-receive and update.
+Manage custom hook files within a GitLab project. Custom hooks can be created as a pre-receive, post-receive, or update hook. Only one of each is currently supported by this module.
 
 #### Examples
 
@@ -1194,10 +1193,10 @@ It is possible to create different custom hook types for the same project - one 
 
 ```puppet
 gitlab::custom_hook { 'my_custom_hook':
-  namespace       => 'my_group',
-  project         => 'my_project',
-  type            => 'post-receive',
-  source          => 'puppet:///modules/my_module/post-receive',
+  namespace      => 'my_group',
+  project        => 'my_project',
+  type           => 'post-receive',
+  source         => 'puppet:///modules/my_module/post-receive',
 }
 ```
 
@@ -1205,9 +1204,10 @@ gitlab::custom_hook { 'my_custom_hook':
 
 ```puppet
 gitlab::custom_hook { 'my_custom_hook':
-  project         => 93,
-  type            => 'post-receive',
-  source          => 'puppet:///modules/my_module/post-receive',
+  project        => 93,
+  hashed_storage => true,
+  type           => 'post-receive',
+  source         => 'puppet:///modules/my_module/post-receive',
 }
 # Hook path will be `@hashed/6e/40/6e4001871c0cf27c7634ef1dc478408f642410fd3a444e2a88e301f5c4a35a4d`
 ```
@@ -1248,8 +1248,7 @@ The custom hook type. Should be one of pre-receive, post-receive, or update.
 
 Data type: `Optional[String]`
 
-Specify the custom hook contents either as a string or using the template function. If this paramter is specified source
-parameter must not be present.
+Specify the custom hook contents either as a string or using the template function. If this paramter is specified source parameter must not be present.
 
 Default value: `undef`
 
@@ -1257,8 +1256,7 @@ Default value: `undef`
 
 Data type: `Optional[String]`
 
-Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not
-be present.
+Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not be present.
 
 Default value: `undef`
 
@@ -1280,9 +1278,7 @@ Default value: `false`
 
 ### <a name="gitlab--global_hook"></a>`gitlab::global_hook`
 
-Hooks can be created as a pre-receive, post-receive, or update hook.
-It's possible to create  multipe hooks per type as long as their names are unique.
-Support for chained (global) hooks is introduced in GitLab Shell 4.1.0 and GitLab 8.15.
+Manage global chain loaded hook files for all GitLab projects. Hooks can be created as a pre-receive, post-receive, or update hook. It's possible to create  multipe hooks per type as long as their names are unique. Support for chained (global) hooks is introduced in GitLab Shell 4.1.0 and GitLab 8.15.
 
 #### Examples
 
@@ -1322,8 +1318,7 @@ Default value: `$gitlab::custom_hooks_dir`
 
 Data type: `Optional[String[1]]`
 
-Specify the custom hook contents either as a string or using the template function. If this paramter is specified source
-parameter must not be present.
+Specify the custom hook contents either as a string or using the template function. If this paramter is specified source parameter must not be present.
 
 Default value: `undef`
 
@@ -1331,8 +1326,7 @@ Default value: `undef`
 
 Data type: `Optional[Pattern[/^puppet:/]]`
 
-Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not
-be present.
+Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not be present.
 
 Default value: `undef`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -16,8 +16,8 @@
 
 ### Defined types
 
-* [`gitlab::custom_hook`](#gitlab--custom_hook): Manage custom hook files within a GitLab project. Custom hooks can be created as a pre-receive, post-receive, or update hook. It's possible to create different custom hook types for the same project - one each for pre-receive, post-receive and update.
-* [`gitlab::global_hook`](#gitlab--global_hook): Manage global chain loaded hook files for all GitLab projects. Hooks can be created as a pre-receive, post-receive, or update hook. It's possible to create  multipe hooks per type as long as their names are unique. Support for chained (global) hooks is introduced in GitLab Shell 4.1.0 and GitLab 8.15.
+* [`gitlab::custom_hook`](#gitlab--custom_hook): Manage custom hook files within a GitLab project.
+* [`gitlab::global_hook`](#gitlab--global_hook): Manage global chain loaded hook files for all GitLab projects.
 * [`gitlab::system_hook`](#gitlab--system_hook): A file hook will run on each event so it's up to you to filter events or projects
 
 ### Tasks
@@ -1185,7 +1185,8 @@ Default value: `$gitlab::skip_post_deployment_migrations`
 
 ### <a name="gitlab--custom_hook"></a>`gitlab::custom_hook`
 
-Manage custom hook files within a GitLab project. Custom hooks can be created as a pre-receive, post-receive, or update hook. It's possible to create different custom hook types for the same project - one each for pre-receive, post-receive and update.
+Custom hooks can be created as a pre-receive, post-receive, or update hook.
+It is possible to create different custom hook types for the same project - one each for pre-receive, post-receive and update.
 
 #### Examples
 
@@ -1200,28 +1201,42 @@ gitlab::custom_hook { 'my_custom_hook':
 }
 ```
 
+##### Calculate hashed storage path
+
+```puppet
+gitlab::custom_hook { 'my_custom_hook':
+  project         => 93,
+  type            => 'post-receive',
+  source          => 'puppet:///modules/my_module/post-receive',
+}
+# Hook path will be `@hashed/6e/40/6e4001871c0cf27c7634ef1dc478408f642410fd3a444e2a88e301f5c4a35a4d`
+```
+
 #### Parameters
 
 The following parameters are available in the `gitlab::custom_hook` defined type:
 
-* [`namespace`](#-gitlab--custom_hook--namespace)
 * [`project`](#-gitlab--custom_hook--project)
+* [`namespace`](#-gitlab--custom_hook--namespace)
 * [`type`](#-gitlab--custom_hook--type)
 * [`content`](#-gitlab--custom_hook--content)
 * [`source`](#-gitlab--custom_hook--source)
 * [`repos_path`](#-gitlab--custom_hook--repos_path)
-
-##### <a name="-gitlab--custom_hook--namespace"></a>`namespace`
-
-Data type: `String`
-
-The GitLab group namespace for the project.
+* [`hashed_storage`](#-gitlab--custom_hook--hashed_storage)
 
 ##### <a name="-gitlab--custom_hook--project"></a>`project`
 
-Data type: `String`
+Data type: `Variant[String,Integer]`
 
-The GitLab project name.
+The GitLab project name, or the hashed directory name or project ID number
+
+##### <a name="-gitlab--custom_hook--namespace"></a>`namespace`
+
+Data type: `Optional[String]`
+
+The GitLab group namespace for the project.
+
+Default value: `undef`
 
 ##### <a name="-gitlab--custom_hook--type"></a>`type`
 
@@ -1233,7 +1248,8 @@ The custom hook type. Should be one of pre-receive, post-receive, or update.
 
 Data type: `Optional[String]`
 
-Specify the custom hook contents either as a string or using the template function. If this paramter is specified source parameter must not be present.
+Specify the custom hook contents either as a string or using the template function. If this paramter is specified source
+parameter must not be present.
 
 Default value: `undef`
 
@@ -1241,7 +1257,8 @@ Default value: `undef`
 
 Data type: `Optional[String]`
 
-Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not be present.
+Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not
+be present.
 
 Default value: `undef`
 
@@ -1253,9 +1270,19 @@ The GitLab shell repos path. This defaults to '/var/opt/gitlab/git-data/reposito
 
 Default value: `undef`
 
+##### <a name="-gitlab--custom_hook--hashed_storage"></a>`hashed_storage`
+
+Data type: `Boolean`
+
+Whether to treat the project name as a hashed storage directory name or ID number
+
+Default value: `false`
+
 ### <a name="gitlab--global_hook"></a>`gitlab::global_hook`
 
-Manage global chain loaded hook files for all GitLab projects. Hooks can be created as a pre-receive, post-receive, or update hook. It's possible to create  multipe hooks per type as long as their names are unique. Support for chained (global) hooks is introduced in GitLab Shell 4.1.0 and GitLab 8.15.
+Hooks can be created as a pre-receive, post-receive, or update hook.
+It's possible to create  multipe hooks per type as long as their names are unique.
+Support for chained (global) hooks is introduced in GitLab Shell 4.1.0 and GitLab 8.15.
 
 #### Examples
 
@@ -1295,7 +1322,8 @@ Default value: `$gitlab::custom_hooks_dir`
 
 Data type: `Optional[String[1]]`
 
-Specify the custom hook contents either as a string or using the template function. If this paramter is specified source parameter must not be present.
+Specify the custom hook contents either as a string or using the template function. If this paramter is specified source
+parameter must not be present.
 
 Default value: `undef`
 
@@ -1303,7 +1331,8 @@ Default value: `undef`
 
 Data type: `Optional[Pattern[/^puppet:/]]`
 
-Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not be present.
+Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not
+be present.
 
 Default value: `undef`
 

--- a/manifests/custom_hook.pp
+++ b/manifests/custom_hook.pp
@@ -1,4 +1,8 @@
-# @summary Manage custom hook files within a GitLab project. Custom hooks can be created as a pre-receive, post-receive, or update hook. It's possible to create different custom hook types for the same project - one each for pre-receive, post-receive and update.
+# @summary
+#     Manage custom hook files within a GitLab project.
+#
+# Custom hooks can be created as a pre-receive, post-receive, or update hook.
+# It is possible to create different custom hook types for the same project - one each for pre-receive, post-receive and update.
 #
 # @example Custom hook usage
 #   gitlab::custom_hook { 'my_custom_hook':
@@ -19,10 +23,13 @@
 # @param project The GitLab project name, or the hashed directory name or project ID number
 # @param namespace The GitLab group namespace for the project.
 # @param type The custom hook type. Should be one of pre-receive, post-receive, or update.
-# @param content Specify the custom hook contents either as a string or using the template function. If this paramter is specified source parameter must not be present.
-# @param source Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not be present.
+# @param content Specify the custom hook contents either as a string or using the template function. If this paramter is specified source
+#        parameter must not be present.
+# @param source Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not
+#        be present.
 # @param repos_path The GitLab shell repos path. This defaults to '/var/opt/gitlab/git-data/repositories' if not present.
 # @param hashed_storage Whether to treat the project name as a hashed storage directory name or ID number
+#
 define gitlab::custom_hook (
   Variant[String,Integer]                       $project,
   Enum['update', 'post-receive', 'pre-receive'] $type,
@@ -30,7 +37,7 @@ define gitlab::custom_hook (
   Optional[String]                              $content = undef,
   Optional[String]                              $source = undef,
   Optional[Stdlib::Absolutepath]                $repos_path = undef,
-  Optional[Boolean]                             $hashed_storage = false,
+  Boolean                                       $hashed_storage = false,
 ) {
   if $repos_path {
     $_repos_path = $repos_path

--- a/manifests/custom_hook.pp
+++ b/manifests/custom_hook.pp
@@ -8,19 +8,29 @@
 #     source          => 'puppet:///modules/my_module/post-receive',
 #   }
 #
+# @example Calculate hashed storage path
+#   gitlab::custom_hook { 'my_custom_hook':
+#     project         => 93,
+#     type            => 'post-receive',
+#     source          => 'puppet:///modules/my_module/post-receive',
+#   }
+#   # Hook path will be `@hashed/6e/40/6e4001871c0cf27c7634ef1dc478408f642410fd3a444e2a88e301f5c4a35a4d`
+#
+# @param project The GitLab project name, or the hashed directory name or project ID number
 # @param namespace The GitLab group namespace for the project.
-# @param project The GitLab project name.
 # @param type The custom hook type. Should be one of pre-receive, post-receive, or update.
 # @param content Specify the custom hook contents either as a string or using the template function. If this paramter is specified source parameter must not be present.
 # @param source Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not be present.
 # @param repos_path The GitLab shell repos path. This defaults to '/var/opt/gitlab/git-data/repositories' if not present.
+# @param hashed_storage Whether to treat the project name as a hashed storage directory name or ID number
 define gitlab::custom_hook (
-  String                                        $namespace,
-  String                                        $project,
+  Variant[String,Integer]                       $project,
   Enum['update', 'post-receive', 'pre-receive'] $type,
+  Optional[String]                              $namespace = undef,
   Optional[String]                              $content = undef,
   Optional[String]                              $source = undef,
   Optional[Stdlib::Absolutepath]                $repos_path = undef,
+  Optional[Boolean]                             $hashed_storage = false,
 ) {
   if $repos_path {
     $_repos_path = $repos_path
@@ -38,7 +48,29 @@ define gitlab::custom_hook (
     fail("gitlab::custom_hook[${name}]: Must specify either content or source, but not both")
   }
 
-  $hook_path = "${_repos_path}/${namespace}/${project}.git/custom_hooks"
+  if ! ($hashed_storage) and ! ($namespace) {
+    fail("gitlab::custom_hook[${name}]: Must specify either namespace or hashed_storage")
+  }
+
+  if ($hashed_storage) and ($namespace) {
+    fail("gitlab::custom_hook[${name}]: Must specify either namespace or hashed_storage, but not both")
+  }
+
+  if ($namespace) {
+    $hook_path = "${_repos_path}/${namespace}/${project}.git/custom_hooks"
+  } elsif ($hashed_storage) {
+    if ($project.is_a(Integer)) {
+      $_project_hash = sha256(String($project))
+    } else {
+      $_project_hash = $project
+    }
+
+    if ($_project_hash.length != 64) {
+      fail("gitlab::custom_hook[${name}]: Invalid project hash ${_project_hash}")
+    }
+
+    $hook_path = "${_repos_path}/@hashed/${_project_hash[0,2]}/${_project_hash[2,2]}/${_project_hash}.git/custom_hooks"
+  }
 
   File {
     owner => $gitlab::service_user,

--- a/manifests/custom_hook.pp
+++ b/manifests/custom_hook.pp
@@ -1,32 +1,27 @@
-# @summary
-#     Manage custom hook files within a GitLab project.
-#
-# Custom hooks can be created as a pre-receive, post-receive, or update hook.
-# It is possible to create different custom hook types for the same project - one each for pre-receive, post-receive and update.
+# @summary Manage custom hook files within a GitLab project. Custom hooks can be created as a pre-receive, post-receive, or update hook. Only one of each is currently supported by this module.
 #
 # @example Custom hook usage
 #   gitlab::custom_hook { 'my_custom_hook':
-#     namespace       => 'my_group',
-#     project         => 'my_project',
-#     type            => 'post-receive',
-#     source          => 'puppet:///modules/my_module/post-receive',
+#     namespace      => 'my_group',
+#     project        => 'my_project',
+#     type           => 'post-receive',
+#     source         => 'puppet:///modules/my_module/post-receive',
 #   }
 #
 # @example Calculate hashed storage path
 #   gitlab::custom_hook { 'my_custom_hook':
-#     project         => 93,
-#     type            => 'post-receive',
-#     source          => 'puppet:///modules/my_module/post-receive',
+#     project        => 93,
+#     hashed_storage => true,
+#     type           => 'post-receive',
+#     source         => 'puppet:///modules/my_module/post-receive',
 #   }
 #   # Hook path will be `@hashed/6e/40/6e4001871c0cf27c7634ef1dc478408f642410fd3a444e2a88e301f5c4a35a4d`
 #
 # @param project The GitLab project name, or the hashed directory name or project ID number
 # @param namespace The GitLab group namespace for the project.
 # @param type The custom hook type. Should be one of pre-receive, post-receive, or update.
-# @param content Specify the custom hook contents either as a string or using the template function. If this paramter is specified source
-#        parameter must not be present.
-# @param source Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not
-#        be present.
+# @param content Specify the custom hook contents either as a string or using the template function. If this paramter is specified source parameter must not be present.
+# @param source Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not be present.
 # @param repos_path The GitLab shell repos path. This defaults to '/var/opt/gitlab/git-data/repositories' if not present.
 # @param hashed_storage Whether to treat the project name as a hashed storage directory name or ID number
 #

--- a/manifests/global_hook.pp
+++ b/manifests/global_hook.pp
@@ -1,4 +1,9 @@
-# @summary Manage global chain loaded hook files for all GitLab projects. Hooks can be created as a pre-receive, post-receive, or update hook. It's possible to create  multipe hooks per type as long as their names are unique. Support for chained (global) hooks is introduced in GitLab Shell 4.1.0 and GitLab 8.15.
+# @summary
+#     Manage global chain loaded hook files for all GitLab projects.
+#
+# Hooks can be created as a pre-receive, post-receive, or update hook.
+# It's possible to create  multipe hooks per type as long as their names are unique.
+# Support for chained (global) hooks is introduced in GitLab Shell 4.1.0 and GitLab 8.15.
 #
 # @example Global hook usage
 #   gitlab::custom_hook { 'my_custom_hook':
@@ -8,8 +13,11 @@
 #
 # @param type The custom hook type. Should be one of pre-receive, post-receive, or update.
 # @param custom_hooks_dir The GitLab shell repos path. This defaults to '/opt/gitlab/embedded/service/gitlab-shell/hooks' if not present.
-# @param content Specify the custom hook contents either as a string or using the template function. If this paramter is specified source parameter must not be present.
-# @param source Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not be present.
+# @param content Specify the custom hook contents either as a string or using the template function. If this paramter is specified source
+#        parameter must not be present.
+# @param source Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not
+#        be present.
+#
 define gitlab::global_hook (
   Enum['post-receive', 'pre-receive', 'update'] $type,
   Stdlib::Absolutepath                          $custom_hooks_dir = $gitlab::custom_hooks_dir,

--- a/manifests/global_hook.pp
+++ b/manifests/global_hook.pp
@@ -1,9 +1,4 @@
-# @summary
-#     Manage global chain loaded hook files for all GitLab projects.
-#
-# Hooks can be created as a pre-receive, post-receive, or update hook.
-# It's possible to create  multipe hooks per type as long as their names are unique.
-# Support for chained (global) hooks is introduced in GitLab Shell 4.1.0 and GitLab 8.15.
+# @summary Manage global chain loaded hook files for all GitLab projects. Hooks can be created as a pre-receive, post-receive, or update hook. It's possible to create  multipe hooks per type as long as their names are unique. Support for chained (global) hooks is introduced in GitLab Shell 4.1.0 and GitLab 8.15.
 #
 # @example Global hook usage
 #   gitlab::custom_hook { 'my_custom_hook':
@@ -13,11 +8,8 @@
 #
 # @param type The custom hook type. Should be one of pre-receive, post-receive, or update.
 # @param custom_hooks_dir The GitLab shell repos path. This defaults to '/opt/gitlab/embedded/service/gitlab-shell/hooks' if not present.
-# @param content Specify the custom hook contents either as a string or using the template function. If this paramter is specified source
-#        parameter must not be present.
-# @param source Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not
-#        be present.
-#
+# @param content Specify the custom hook contents either as a string or using the template function. If this paramter is specified source parameter must not be present.
+# @param source Specify a file source path to populate the custom hook contents. If this paramter is specified content parameter must not be present.
 define gitlab::global_hook (
   Enum['post-receive', 'pre-receive', 'update'] $type,
   Stdlib::Absolutepath                          $custom_hooks_dir = $gitlab::custom_hooks_dir,

--- a/spec/defines/custom_hook_spec.rb
+++ b/spec/defines/custom_hook_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'gitlab::custom_hook' do
+  let(:title) { 'test-hook' }
+
+  let(:pre_condition) do
+    <<-MANIFEST
+    class { 'gitlab':
+      repository_configuration => {},
+    }
+    MANIFEST
+  end
+
+  ['post-receive', 'pre-receive', 'update'].each do |type|
+    context "with type => #{type} and source" do
+      let(:source) { 'puppet:///modules/my_module/post-receive' }
+      let(:params) do
+        {
+          type: type,
+          repos_path: '/custom/hooks/dir',
+          source: source,
+          namespace: 'foo',
+          project: 'bar'
+        }
+      end
+
+      it { is_expected.to compile }
+
+      it do
+        is_expected.to contain_file('/custom/hooks/dir/foo/bar.git/custom_hooks').
+          with_ensure('directory')
+      end
+
+      it do
+        is_expected.to contain_file("/custom/hooks/dir/foo/bar.git/custom_hooks/#{type}").
+          with_ensure('file').
+          with_source(source)
+      end
+    end
+
+    context "with type => #{type} and content" do
+      let(:content) { "#!/usr/bin/env bash\ntest 0" }
+      let(:params) do
+        {
+          type: type,
+          repos_path: '/custom/hooks/dir',
+          content: content,
+          namespace: 'foo',
+          project: 'bar'
+        }
+      end
+
+      it { is_expected.to compile }
+
+      it do
+        is_expected.to contain_file('/custom/hooks/dir/foo/bar.git/custom_hooks').
+          with_ensure('directory')
+      end
+
+      it do
+        is_expected.to contain_file("/custom/hooks/dir/foo/bar.git/custom_hooks/#{type}").
+          with_ensure('file').
+          with_content(content)
+      end
+    end
+
+    context "with type => #{type} and project hash" do
+      let(:content) { "#!/usr/bin/env bash\ntest 0" }
+      let(:params) do
+        {
+          type: type,
+          repos_path: '/custom/hooks/dir',
+          content: content,
+          hashed_storage: true,
+          project: '6e4001871c0cf27c7634ef1dc478408f642410fd3a444e2a88e301f5c4a35a4d'
+        }
+      end
+
+      it { is_expected.to compile }
+
+      it do
+        is_expected.to contain_file('/custom/hooks/dir/@hashed/6e/40/6e4001871c0cf27c7634ef1dc478408f642410fd3a444e2a88e301f5c4a35a4d.git/custom_hooks').
+          with_ensure('directory')
+      end
+
+      it do
+        is_expected.to contain_file("/custom/hooks/dir/@hashed/6e/40/6e4001871c0cf27c7634ef1dc478408f642410fd3a444e2a88e301f5c4a35a4d.git/custom_hooks/#{type}").
+          with_ensure('file').
+          with_content(content)
+      end
+    end
+
+    context "with type => #{type} and project id" do
+      let(:content) { "#!/usr/bin/env bash\ntest 0" }
+      let(:params) do
+        {
+          type: type,
+          repos_path: '/custom/hooks/dir',
+          content: content,
+          hashed_storage: true,
+          project: 93
+        }
+      end
+
+      it { is_expected.to compile }
+
+      it do
+        is_expected.to contain_file('/custom/hooks/dir/@hashed/6e/40/6e4001871c0cf27c7634ef1dc478408f642410fd3a444e2a88e301f5c4a35a4d.git/custom_hooks').
+          with_ensure('directory')
+      end
+
+      it do
+        is_expected.to contain_file("/custom/hooks/dir/@hashed/6e/40/6e4001871c0cf27c7634ef1dc478408f642410fd3a444e2a88e301f5c4a35a4d.git/custom_hooks/#{type}").
+          with_ensure('file').
+          with_content(content)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description
Add hashed repository storage support for `custom_hook`. Also add tests for `custom_hook`.

#### This Pull Request (PR) fixes the following issues
Partial solution to #322 