### PR TITLE
fix apt-key deprecation

### DIFF
--- a/data/family/Debian.yaml
+++ b/data/family/Debian.yaml
@@ -6,11 +6,11 @@ gitlab::repository_configuration:
       comment: 'Official repository for GitLab Omnibus'
       location: "https://packages.gitlab.com/gitlab/gitlab-ce/debian"
       key:
-        name: 'gitlab.asc'
+        name: 'gitlab_ce.asc'
         source: 'https://packages.gitlab.com/gpg.key'
     "gitlab_official_ee":
       comment: 'Official repository for GitLab Omnibus'
       location: "https://packages.gitlab.com/gitlab/gitlab-ee/debian"
       key:
-        name: 'gitlab.asc'
+        name: 'gitlab_ee.asc'
         source: 'https://packages.gitlab.com/gpg.key'

--- a/data/family/Debian.yaml
+++ b/data/family/Debian.yaml
@@ -6,11 +6,11 @@ gitlab::repository_configuration:
       comment: 'Official repository for GitLab Omnibus'
       location: "https://packages.gitlab.com/gitlab/gitlab-ce/debian"
       key:
-        id: 'F6403F6544A38863DAA0B6E03F01618A51312F3F'
+        name: 'gitlab.asc'
         source: 'https://packages.gitlab.com/gpg.key'
     "gitlab_official_ee":
       comment: 'Official repository for GitLab Omnibus'
       location: "https://packages.gitlab.com/gitlab/gitlab-ee/debian"
       key:
-        id: 'F6403F6544A38863DAA0B6E03F01618A51312F3F'
+        name: 'gitlab.asc'
         source: 'https://packages.gitlab.com/gpg.key'


### PR DESCRIPTION
#### Pull Request (PR) description
On modern debian-based systems, we now get the error "Key is stored in legacy trusted.gpg keyring (/etc/apt/trusted.gpg), see the DEPRECATION section in apt-key(8) for details."
With this pull-request I'm trying to fix it.

#### This Pull Request (PR) fixes the following issues
n/a
