### PR TITLE
Fix apt-key deprecation on Ubuntu

### DIFF
--- a/data/os/Ubuntu.yaml
+++ b/data/os/Ubuntu.yaml
@@ -6,11 +6,11 @@ gitlab::repository_configuration:
       comment: 'Official repository for GitLab Omnibus'
       location: "https://packages.gitlab.com/gitlab/gitlab-ce/ubuntu"
       key:
-        id: 'F6403F6544A38863DAA0B6E03F01618A51312F3F'
+        name: 'gitlab_ce.asc'
         source: 'https://packages.gitlab.com/gpg.key'
     "gitlab_official_ee":
       comment: 'Official repository for GitLab Omnibus'
       location: "https://packages.gitlab.com/gitlab/gitlab-ee/ubuntu"
       key:
-        id: 'F6403F6544A38863DAA0B6E03F01618A51312F3F'
+        name: 'gitlab_ee.asc'
         source: 'https://packages.gitlab.com/gpg.key'


### PR DESCRIPTION
Same as https://github.com/voxpupuli/puppet-gitlab/pull/432 except for Ubuntu.