### PR TITLE
[security] Sensitive type for gitlab_rails

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -419,7 +419,7 @@ Default value: `undef`
 
 ##### <a name="-gitlab--gitlab_rails"></a>`gitlab_rails`
 
-Data type: `Optional[Hash]`
+Data type: `Optional[Variant[Hash,Sensitive[Hash]]]`
 
 Hash of 'gitlab_pages' config parameters.
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,7 +165,7 @@ class gitlab (
   Optional[Hash]                      $gitlab_ci                       = undef,
   Optional[Hash]                      $gitlab_kas                      = undef,
   Optional[Hash]                      $gitlab_pages                    = undef,
-  Optional[Hash]                      $gitlab_rails                    = undef,
+  Optional[Variant[Hash,Sensitive[Hash]]] $gitlab_rails                = undef,
   Optional[Hash]                      $gitlab_sshd                     = undef,
   Optional[Hash]                      $grafana                         = undef,
   Optional[Hash]                      $high_availability               = undef,

--- a/manifests/omnibus_config.pp
+++ b/manifests/omnibus_config.pp
@@ -119,6 +119,7 @@ class gitlab::omnibus_config (
         source => $source_config_file,
       }
     } else {
+      $gitlab_rails_unwrap = $gitlab_rails.unwrap
       file { $config_file:
         *       => $config_file_attributes,
         content => template('gitlab/gitlab.rb.erb');

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -63,14 +63,21 @@ roles <%= decorate(@roles) %>
 git_data_dirs(<%= decorate(@git_data_dirs) %>)
 
 <%- end -%>
-<%- if @gitlab_rails -%>
+<%-
+if @gitlab_rails
+  if @gitlab_rails.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
+    gitlab_rails = @gitlab_rails.unwrap
+  else
+    gitlab_rails = @gitlab_rails
+  end
+-%>
 
 ############################
 # gitlab.yml configuration #
 ############################
 
-<%- @gitlab_rails.keys.sort.each do |k| -%>
-gitlab_rails['<%= k -%>'] = <%= decorate(@gitlab_rails[k]) %>
+<%- gitlab_rails.keys.sort.each do |k| -%>
+gitlab_rails['<%= k -%>'] = <%= decorate(gitlab_rails[k]) %>
 <%- end end -%>
 <%- if @user -%>
 

--- a/templates/gitlab.rb.erb
+++ b/templates/gitlab.rb.erb
@@ -63,21 +63,14 @@ roles <%= decorate(@roles) %>
 git_data_dirs(<%= decorate(@git_data_dirs) %>)
 
 <%- end -%>
-<%-
-if @gitlab_rails
-  if @gitlab_rails.is_a?(Puppet::Pops::Types::PSensitiveType::Sensitive)
-    gitlab_rails = @gitlab_rails.unwrap
-  else
-    gitlab_rails = @gitlab_rails
-  end
--%>
+<%- if @gitlab_rails_unwrap -%>
 
 ############################
 # gitlab.yml configuration #
 ############################
 
-<%- gitlab_rails.keys.sort.each do |k| -%>
-gitlab_rails['<%= k -%>'] = <%= decorate(gitlab_rails[k]) %>
+<%- @gitlab_rails_unwrap.keys.sort.each do |k| -%>
+gitlab_rails['<%= k -%>'] = <%= decorate(@gitlab_rails_unwrap[k]) %>
 <%- end end -%>
 <%- if @user -%>
 


### PR DESCRIPTION
#### Pull Request (PR) description

LDAP crendentials can be passed through gitlab_rails, which will appear in clear in Puppetdb for the class attributes.

This commit permits to hide from the class attributes inside PuppetDB, but still renders the password visible inside PuppetDB with the generated content of the template.

#### This Pull Request (PR) fixes the following issues

https://github.com/voxpupuli/puppet-gitlab/issues/486